### PR TITLE
Add room filtering UI and command

### DIFF
--- a/App.xaml
+++ b/App.xaml
@@ -11,6 +11,7 @@
         <conv:DateDiffConverter x:Key="DateDiffConverter"/>
         <conv:NightsCalculatorConverter x:Key="NightsCalculatorConverter"/>
         <conv:FilterHotelConverter x:Key="FilterHotelConverter"/>
+        <conv:FilterRoomConverter x:Key="FilterRoomConverter"/>
         <conv:StatusToColorConverter x:Key="StatusToColorConverter"/>
         <conv:TotalAmountCalculatorConverter x:Key="TotalAmountCalculatorConverter"/>
         <conv:RoomIdToRoomNumberConverter x:Key="RoomIdToRoomNumberConverter"/>

--- a/Converters/FilterRoomConverter.cs
+++ b/Converters/FilterRoomConverter.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace Hotel_Booking_System.Converters
+{
+    class FilterRoomConverter : IMultiValueConverter
+    {
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            double? minPrice = null;
+            if (double.TryParse(values[0]?.ToString(), out var min))
+                minPrice = min;
+
+            double? maxPrice = null;
+            if (double.TryParse(values[1]?.ToString(), out var max))
+                maxPrice = max;
+
+            int? capacity = null;
+            if (int.TryParse(values[2]?.ToString(), out var cap))
+                capacity = cap;
+
+            bool? freeWifi = values[3] as bool?;
+            bool? swimmingPool = values[4] as bool?;
+            bool? freeParking = values[5] as bool?;
+            bool? restaurant = values[6] as bool?;
+            bool? gym = values[7] as bool?;
+
+            var filterDict = new Dictionary<string, object?>
+            {
+                { "MinPrice", minPrice },
+                { "MaxPrice", maxPrice },
+                { "Capacity", capacity },
+                { "FreeWifi", freeWifi },
+                { "SwimmingPool", swimmingPool },
+                { "FreeParking", freeParking },
+                { "Restaurant", restaurant },
+                { "Gym", gym }
+            };
+
+            return filterDict;
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/ViewModels/UserViewModel.cs
+++ b/ViewModels/UserViewModel.cs
@@ -280,6 +280,50 @@ namespace Hotel_Booking_System.ViewModels
 
 
         }
+
+        [RelayCommand]
+        private void FilterRooms(object parameter)
+        {
+            if (parameter is Dictionary<string, object?> filterParams && CurrentHotel != null)
+            {
+                double? minPrice = filterParams.TryGetValue("MinPrice", out var min) && min is double dmin ? dmin : null;
+                double? maxPrice = filterParams.TryGetValue("MaxPrice", out var max) && max is double dmax ? dmax : null;
+                int? capacity = filterParams.TryGetValue("Capacity", out var cap) && cap is int icap ? icap : null;
+                bool? freeWifi = filterParams.TryGetValue("FreeWifi", out var wifi) ? wifi as bool? : null;
+                bool? swimmingPool = filterParams.TryGetValue("SwimmingPool", out var pool) ? pool as bool? : null;
+                bool? freeParking = filterParams.TryGetValue("FreeParking", out var parking) ? parking as bool? : null;
+                bool? restaurant = filterParams.TryGetValue("Restaurant", out var rest) ? rest as bool? : null;
+                bool? gym = filterParams.TryGetValue("Gym", out var gymVal) ? gymVal as bool? : null;
+
+                var rooms = Rooms.Where(r => r.HotelID == CurrentHotel.HotelID).ToList();
+
+                if (minPrice.HasValue)
+                    rooms = rooms.Where(r => r.PricePerNight >= minPrice.Value).ToList();
+                if (maxPrice.HasValue)
+                    rooms = rooms.Where(r => r.PricePerNight <= maxPrice.Value).ToList();
+                if (capacity.HasValue)
+                    rooms = rooms.Where(r => r.Capacity >= capacity.Value).ToList();
+
+                var amenities = CurrentHotel.Amenities.Select(a => a.AmenityName).ToList();
+                if (freeWifi == true && !amenities.Contains("Free WiFi")) rooms = new List<Room>();
+                if (swimmingPool == true && !amenities.Contains("Swimming Pool")) rooms = new List<Room>();
+                if (freeParking == true && !amenities.Contains("Free Parking")) rooms = new List<Room>();
+                if (restaurant == true && !amenities.Contains("Restaurant")) rooms = new List<Room>();
+                if (gym == true && !amenities.Contains("Gym")) rooms = new List<Room>();
+
+                FilteredRooms.Clear();
+                foreach (var room in rooms)
+                    FilteredRooms.Add(room);
+            }
+        }
+
+        [RelayCommand]
+        private void ClearRoomFilters()
+        {
+            if (CurrentHotel != null)
+                FilterRoomsByHotel(CurrentHotel.HotelID);
+        }
+
         [RelayCommand]
         private void ClearSearch()
         {

--- a/Views/UserWindow.xaml
+++ b/Views/UserWindow.xaml
@@ -166,7 +166,8 @@
                                 <Border Visibility="{Binding ShowSearchRoom}" Grid.Column="0" Style="{StaticResource CardStyle}" Height="850" VerticalAlignment="Top">
                                     <StackPanel Margin="25">
                                         <TextBlock HorizontalAlignment="Center" Text="Room Filters" FontSize="18" FontWeight="Bold" Margin="0,0,0,20"/>
-                                        
+
+                                        <TextBlock Text="Price Range ($)" FontWeight="SemiBold" Margin="0,0,0,10"/>
                                         <Border Background="#FFF8F9FA" CornerRadius="8" Padding="15,12" Margin="0,0,0,20">
                                             <StackPanel>
                                                 <Grid Margin="0,0,0,10">
@@ -175,47 +176,39 @@
                                                         <ColumnDefinition Width="Auto"/>
                                                         <ColumnDefinition Width="*"/>
                                                     </Grid.ColumnDefinitions>
-                                            
-                                                    <TextBlock Grid.Column="1" Text="to" 
-                                      VerticalAlignment="Center" 
-                                      Margin="10,0" 
-                                      HorizontalAlignment="Center"/>
-                                                   
+                                                    <TextBox x:Name="txtRoomMinPrice" Width="80" Height="30" HorizontalAlignment="Center"/>
+                                                    <TextBlock Grid.Column="1" Text="to" VerticalAlignment="Center" Margin="10,0" HorizontalAlignment="Center"/>
+                                                    <TextBox x:Name="txtRoomMaxPrice" Grid.Column="2" Width="80" Height="30" HorizontalAlignment="Center"/>
                                                 </Grid>
                                             </StackPanel>
                                         </Border>
 
-                                        <TextBlock Text="Star Rating" FontWeight="SemiBold" Margin="0,0,0,10"/>
-                                        <Border Background="#FFF8F9FA" CornerRadius="8" Padding="15,12" Margin="0,0,0,20">
-                                            <StackPanel>
-                                               
-
-                                            </StackPanel>
-                                        </Border>
+                                        <TextBlock Text="Capacity" FontWeight="SemiBold" Margin="0,0,0,10"/>
+                                        <TextBox x:Name="txtRoomCapacity" Width="80" Height="30" Margin="0,0,0,20"/>
 
                                         <TextBlock Text="Amenities" FontWeight="SemiBold" Margin="0,0,0,10"/>
                                         <Border Background="#FFF8F9FA" CornerRadius="8" Padding="15,12" Margin="0,0,0,20">
                                             <StackPanel>
-                                               
+                                                <CheckBox x:Name="cbRoomFreeWifi" Content="🌐 Free WiFi" Margin="0,5"/>
+                                                <CheckBox x:Name="cbRoomSwimmingPool" Content="🏊 Swimming Pool" Margin="0,5"/>
+                                                <CheckBox x:Name="cbRoomFreeParking" Content="🚗 Free Parking" Margin="0,5"/>
+                                                <CheckBox x:Name="cbRoomRestaurant" Content="🍽️ Restaurant" Margin="0,5"/>
+                                                <CheckBox x:Name="cbRoomGym" Content="🏋️ Gym" Margin="0,5"/>
                                             </StackPanel>
                                         </Border>
-                                        <Button Content="Clear Filters" Command="{Binding ClearSearchCommand}" Style="{StaticResource SecondaryButton}" Width="120" Margin="0,0,0,20"/>
-                                        <Button Command="{Binding SearchHotelsCommand}" Content="Search" Width="120" Margin="0,0,0,20" Style="{StaticResource PrimaryButton}">
+
+                                        <Button Content="Clear Filters" Command="{Binding ClearRoomFiltersCommand}" Style="{StaticResource SecondaryButton}" Width="120" Margin="0,0,0,20"/>
+                                        <Button Command="{Binding FilterRoomsCommand}" Content="Search" Width="120" Margin="0,0,0,20" Style="{StaticResource PrimaryButton}">
                                             <Button.CommandParameter>
-                                                <MultiBinding Converter="{StaticResource FilterHotelConverter}">
-                                                    <Binding ElementName="cbbLocation" Path="Text"/>
-                                                    <Binding ElementName="txtMinPrice" Path="Text"/>
-                                                    <Binding ElementName="txtMaxPrice" Path="Text"/>
-                                                    <Binding ElementName="cbFiveStar" Path="IsChecked"/>
-                                                    <Binding ElementName="cbFourStar" Path="IsChecked"/>
-                                                    <Binding ElementName="cbThreeStar" Path="IsChecked"/>
-                                                    <Binding ElementName="cbTwoStar" Path="IsChecked"/>
-                                                    <Binding ElementName="cbOneStar" Path="IsChecked"/>
-                                                    <Binding ElementName="cbFreeWifi" Path="IsChecked"/>
-                                                    <Binding ElementName="cbSwimmingPool" Path="IsChecked"/>
-                                                    <Binding ElementName="cbFreeParking" Path="IsChecked"/>
-                                                    <Binding ElementName="cbRestaurant" Path="IsChecked"/>
-                                                    <Binding ElementName="cbGym" Path="IsChecked"/>
+                                                <MultiBinding Converter="{StaticResource FilterRoomConverter}">
+                                                    <Binding ElementName="txtRoomMinPrice" Path="Text"/>
+                                                    <Binding ElementName="txtRoomMaxPrice" Path="Text"/>
+                                                    <Binding ElementName="txtRoomCapacity" Path="Text"/>
+                                                    <Binding ElementName="cbRoomFreeWifi" Path="IsChecked"/>
+                                                    <Binding ElementName="cbRoomSwimmingPool" Path="IsChecked"/>
+                                                    <Binding ElementName="cbRoomFreeParking" Path="IsChecked"/>
+                                                    <Binding ElementName="cbRoomRestaurant" Path="IsChecked"/>
+                                                    <Binding ElementName="cbRoomGym" Path="IsChecked"/>
                                                 </MultiBinding>
                                             </Button.CommandParameter>
                                         </Button>


### PR DESCRIPTION
## Summary
- implement converter and view model command to filter rooms by price, capacity, and amenities
- expand room filter UI with price range, capacity input, amenity checkboxes, and search/clear buttons
- register new converter for binding

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68c4149c8da08333b52f1d5204db8282