### PR TITLE
Add payment handling and summary tab

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -37,6 +37,7 @@ namespace Hotel_Booking_System
                                .AddTransient<SignUpWindow>()
                                .AddTransient<UserWindow>()
                                .AddTransient<BookingDialog>()
+                               .AddTransient<PaymentDialog>()
                                .AddTransient<AdminWindow>()
 
                                .AddScoped<IHotelRepository, HotelRepository>()
@@ -45,15 +46,16 @@ namespace Hotel_Booking_System
                                  .AddScoped<IReviewRepository, ReviewRepository>()
                                  .AddScoped<IPaymentRepository, PaymentRepository>()
                                  .AddScoped<IAmenityRepository, AmenityRepository>()
-                                 .AddScoped<IAIChatRepository, AIChatRepository>()
+                                .AddScoped<IAIChatRepository, AIChatRepository>()
                                .AddScoped<IRoomRepository, RoomRepository>()
-                               .AddScoped<IHotelAdminRequestRepository, HotelAdminRequestRepository>()
+                                .AddScoped<IHotelAdminRequestRepository, HotelAdminRequestRepository>()
 
                                .AddScoped<INavigationService, NavigationService>()
                                .AddScoped<IAuthentication, AuthenticationSerivce>()
 
                               .AddScoped<ILoginViewModel, LoginViewModel>()
                               .AddScoped<IBookingViewModel, BookingViewModel>()
+                              .AddScoped<IPaymentViewModel, PaymentViewModel>()
                               .AddScoped<IForgotPasswordViewModel, ForgotPasswordViewModel>()
                               .AddScoped<ISignUpViewModel, SignUpViewModel>()
                               .AddScoped<IUserViewModel, UserViewModel>()

--- a/Interfaces/INavigationService.cs
+++ b/Interfaces/INavigationService.cs
@@ -35,8 +35,16 @@ namespace Hotel_Booking_System.Interfaces
     {
         void CloseBookingDialog();
     }
-    public interface INavigationService : INavigationToAdmin, INavigationToSignUp, INavigationToUser, INavitionToLogin, NavigationToForgotPassword, IOpenBookingDialog, ICloseBookingDialog
+    public interface IOpenPaymentDialog
     {
-        
+        bool OpenPaymentDialog(string bookingId, double amount);
+    }
+    public interface IClosePaymentDialog
+    {
+        void ClosePaymentDialog();
+    }
+    public interface INavigationService : INavigationToAdmin, INavigationToSignUp, INavigationToUser, INavitionToLogin, NavigationToForgotPassword, IOpenBookingDialog, ICloseBookingDialog, IOpenPaymentDialog, IClosePaymentDialog
+    {
+
     }
 }

--- a/Interfaces/IPaymentViewModel.cs
+++ b/Interfaces/IPaymentViewModel.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Hotel_Booking_System.DomainModels;
+
+namespace Hotel_Booking_System.Interfaces
+{
+    internal interface IPaymentViewModel
+    {
+        string BookingID { get; set; }
+        double TotalPayment { get; set; }
+        Task LoadPaymentsAsync();
+    }
+}

--- a/Services/NavigationService.cs
+++ b/Services/NavigationService.cs
@@ -106,5 +106,28 @@ namespace Hotel_Booking_System.Services
         {
             CloseCurrent();
         }
+
+        public bool OpenPaymentDialog(string bookingId, double amount)
+        {
+            var paymentWindow = App.Provider!.GetRequiredService<PaymentDialog>();
+
+            paymentWindow.btnCancel.Click += (s, e) =>
+            {
+                paymentWindow.DialogResult = false;
+                paymentWindow.Close();
+            };
+            paymentWindow.btnPay.Click += (s, e) => paymentWindow.DialogResult = true;
+
+            var vm = App.Provider!.GetRequiredService<IPaymentViewModel>();
+            vm.BookingID = bookingId;
+            vm.TotalPayment = amount;
+            paymentWindow.DataContext = vm;
+            paymentWindow.ShowDialog();
+            return (bool)paymentWindow.DialogResult!;
+        }
+        public void ClosePaymentDialog()
+        {
+            CloseCurrent();
+        }
     }
 }

--- a/ViewModels/BookingViewModel.cs
+++ b/ViewModels/BookingViewModel.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using System.Windows;
 using CommunityToolkit.Mvvm.Input;
 using Hotel_Booking_System.DomainModels;
 using Hotel_Booking_System.Interfaces;
@@ -99,12 +98,9 @@ namespace Hotel_Booking_System.ViewModels
             await _roomRepository.UpdateAsync(SelectedRoom);
             await _bookingRepository.AddAsync(booking);
             await _bookingRepository.SaveAsync();
-            
-            MessageBox.Show("Booked Successfully!", "Success", MessageBoxButton.OK, MessageBoxImage.Information);
 
-           
-
-
+            _navigationService.CloseBookingDialog();
+            _navigationService.OpenPaymentDialog(booking.BookingID, TotalPayment);
         }
     }
 }

--- a/ViewModels/PaymentViewModel.cs
+++ b/ViewModels/PaymentViewModel.cs
@@ -1,0 +1,72 @@
+using CommunityToolkit.Mvvm.Input;
+using Hotel_Booking_System.DomainModels;
+using Hotel_Booking_System.Interfaces;
+using Hotel_Manager.FrameWorks;
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace Hotel_Booking_System.ViewModels
+{
+    internal partial class PaymentViewModel : Bindable, IPaymentViewModel
+    {
+        private readonly IPaymentRepository _paymentRepository;
+        private string _bookingId = string.Empty;
+        private double _totalPayment;
+        private string _method = "Cash";
+        public ObservableCollection<Payment> Payments { get; } = new();
+
+        public PaymentViewModel(IPaymentRepository paymentRepository)
+        {
+            _paymentRepository = paymentRepository;
+        }
+
+        public string BookingID
+        {
+            get => _bookingId;
+            set => Set(ref _bookingId, value);
+        }
+
+        public double TotalPayment
+        {
+            get => _totalPayment;
+            set => Set(ref _totalPayment, value);
+        }
+
+        public string Method
+        {
+            get => _method;
+            set => Set(ref _method, value);
+        }
+
+        public double TotalRevenue => Payments.Sum(p => p.TotalPayment);
+
+        public async Task LoadPaymentsAsync()
+        {
+            Payments.Clear();
+            var payments = await _paymentRepository.GetAllAsync();
+            foreach (var p in payments)
+                Payments.Add(p);
+            PropertyChanged?.Invoke(this, new(nameof(TotalRevenue)));
+        }
+
+        [RelayCommand]
+        private async Task ConfirmPayment()
+        {
+            var payment = new Payment
+            {
+                BookingID = BookingID,
+                TotalPayment = TotalPayment,
+                Method = Method,
+                PaymentDate = DateTime.Now
+            };
+            await _paymentRepository.AddAsync(payment);
+            await _paymentRepository.SaveAsync();
+            Payments.Add(payment);
+            PropertyChanged?.Invoke(this, new(nameof(TotalRevenue)));
+            MessageBox.Show("Payment Successful!", "Success", MessageBoxButton.OK, MessageBoxImage.Information);
+        }
+    }
+}

--- a/Views/PaymentDialog.xaml
+++ b/Views/PaymentDialog.xaml
@@ -1,0 +1,61 @@
+<Window x:Class="Hotel_Booking_System.Views.PaymentDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Payment"
+        Height="300" Width="400"
+        WindowStartupLocation="CenterScreen"
+        ResizeMode="NoResize"
+        Background="Transparent"
+        WindowStyle="None"
+        AllowsTransparency="True">
+    <Border CornerRadius="20"
+            Background="White"
+            Padding="20"
+            SnapsToDevicePixels="True">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <TextBlock Text="Payment"
+                       FontSize="18" FontWeight="Bold"
+                       Foreground="#2C3E50"
+                       HorizontalAlignment="Center"
+                       Margin="0,0,0,20"/>
+
+            <StackPanel Grid.Row="1" Margin="0,5">
+                <TextBlock Text="Amount" FontSize="12" Foreground="#7F8C8D"/>
+                <TextBlock Text="{Binding TotalPayment, StringFormat='${0:F0}'}"
+                           FontSize="20" FontWeight="Bold"
+                           Foreground="#27AE60"/>
+            </StackPanel>
+
+            <StackPanel Grid.Row="2" Margin="0,5">
+                <TextBlock Text="Method" FontSize="12" Foreground="#7F8C8D"/>
+                <ComboBox SelectedItem="{Binding Method}"
+                          Height="32" BorderBrush="#BDC3C7" BorderThickness="1">
+                    <ComboBoxItem Content="Cash"/>
+                    <ComboBoxItem Content="Credit Card"/>
+                    <ComboBoxItem Content="Bank Transfer"/>
+                </ComboBox>
+            </StackPanel>
+
+            <StackPanel Grid.Row="5" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,20,0,0">
+                <Button Content="Cancel" Width="90" Height="36"
+                        x:Name="btnCancel"
+                        Background="#ECF0F1" Foreground="#2C3E50"
+                        BorderBrush="{x:Null}"
+                        Margin="0,0,10,0"/>
+                <Button Content="Pay" Width="100" Height="36"
+                        x:Name="btnPay"
+                        Command="{Binding ConfirmPaymentCommand}"
+                        Background="#27AE60" Foreground="White" FontWeight="Bold" BorderBrush="{x:Null}"/>
+            </StackPanel>
+        </Grid>
+    </Border>
+</Window>

--- a/Views/PaymentDialog.xaml.cs
+++ b/Views/PaymentDialog.xaml.cs
@@ -1,0 +1,15 @@
+using System.Windows;
+
+namespace Hotel_Booking_System.Views
+{
+    /// <summary>
+    /// Interaction logic for PaymentDialog.xaml
+    /// </summary>
+    public partial class PaymentDialog : Window
+    {
+        public PaymentDialog()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Views/SuperAdminWindow.xaml
+++ b/Views/SuperAdminWindow.xaml
@@ -827,6 +827,24 @@ Margin="50" Padding="0">
 
             </TabItem>
 
+            <TabItem x:Name="PaymentSummaryTab" Header="💰 Payment Summary">
+                <ScrollViewer Margin="30,20" VerticalScrollBarVisibility="Auto">
+                    <StackPanel>
+                        <TextBlock Text="Payment Summary" Style="{StaticResource HeaderTextStyle}"/>
+                        <DataGrid ItemsSource="{Binding Payments}" AutoGenerateColumns="False" CanUserAddRows="False" Margin="0,20,0,20">
+                            <DataGrid.Columns>
+                                <DataGridTextColumn Header="Payment ID" Binding="{Binding PaymentID}" Width="*"/>
+                                <DataGridTextColumn Header="Booking ID" Binding="{Binding BookingID}" Width="*"/>
+                                <DataGridTextColumn Header="Amount" Binding="{Binding TotalPayment}" Width="*"/>
+                                <DataGridTextColumn Header="Method" Binding="{Binding Method}" Width="*"/>
+                                <DataGridTextColumn Header="Date" Binding="{Binding PaymentDate}" Width="*"/>
+                            </DataGrid.Columns>
+                        </DataGrid>
+                        <TextBlock Text="{Binding TotalRevenue, StringFormat='Total Revenue: ${0:F0}'}" FontSize="16" FontWeight="Bold" Foreground="#27AE60" HorizontalAlignment="Right"/>
+                    </StackPanel>
+                </ScrollViewer>
+            </TabItem>
+
         </TabControl>
     </Grid>
 </Window>

--- a/Views/SuperAdminWindow.xaml.cs
+++ b/Views/SuperAdminWindow.xaml.cs
@@ -11,6 +11,8 @@ using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
+using Hotel_Booking_System.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Hotel_Booking_System.Views
 {
@@ -19,9 +21,12 @@ namespace Hotel_Booking_System.Views
     /// </summary>
     public partial class SuperAdminWindow : Window
     {
+        private readonly IPaymentViewModel _paymentViewModel = App.Provider.GetRequiredService<IPaymentViewModel>();
         public SuperAdminWindow()
         {
             InitializeComponent();
+            PaymentSummaryTab.DataContext = _paymentViewModel;
+            Loaded += async (s, e) => await _paymentViewModel.LoadPaymentsAsync();
         }
     }
 }


### PR DESCRIPTION
## Summary
- add PaymentViewModel and dialog to record payments after bookings
- store new payments and expose total revenue via PaymentRepository
- show Payment Summary tab in SuperAdminWindow listing payments and revenue

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing on Linux)*

------
https://chatgpt.com/codex/tasks/task_e_68c417cdaf6c8333a8ef4f31cb5de2cb