### PR TITLE
Add booking status management commands for user and admin

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -36,8 +36,8 @@ namespace Hotel_Booking_System
                                .AddTransient<ForgotPasswordWindow>()
                                .AddTransient<SignUpWindow>()
                                .AddTransient<UserWindow>()
-                               .AddTransient<BookingDialog>()
-                               .AddTransient<AdminWindow>()
+                              .AddTransient<BookingDialog>()
+                              .AddTransient<AdminWindow>()
 
                                .AddScoped<IHotelRepository, HotelRepository>()
                                .AddSingleton<IBookingRepository, BookingRepository>()
@@ -57,6 +57,7 @@ namespace Hotel_Booking_System
                               .AddScoped<IForgotPasswordViewModel, ForgotPasswordViewModel>()
                               .AddScoped<ISignUpViewModel, SignUpViewModel>()
                               .AddScoped<IUserViewModel, UserViewModel>()
+                              .AddScoped<IAdminViewModel, AdminViewModel>()
                               .BuildServiceProvider();
         }
     }

--- a/Interfaces/IAdminViewModel.cs
+++ b/Interfaces/IAdminViewModel.cs
@@ -1,0 +1,10 @@
+using System.Collections.ObjectModel;
+using Hotel_Booking_System.DomainModels;
+
+namespace Hotel_Booking_System.Interfaces
+{
+    interface IAdminViewModel
+    {
+        ObservableCollection<Booking> Bookings { get; }
+    }
+}

--- a/ViewModels/AdminViewModel.cs
+++ b/ViewModels/AdminViewModel.cs
@@ -1,0 +1,53 @@
+using CommunityToolkit.Mvvm.Input;
+using Hotel_Booking_System.DomainModels;
+using Hotel_Booking_System.Interfaces;
+using Hotel_Manager.FrameWorks;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+
+namespace Hotel_Booking_System.ViewModels
+{
+    public partial class AdminViewModel : Bindable, IAdminViewModel
+    {
+        private readonly IBookingRepository _bookingRepository;
+        public ObservableCollection<Booking> Bookings { get; } = new ObservableCollection<Booking>();
+
+        public AdminViewModel(IBookingRepository bookingRepository)
+        {
+            _bookingRepository = bookingRepository;
+            LoadBookings();
+        }
+
+        private void LoadBookings()
+        {
+            var all = _bookingRepository.GetAllAsync().Result;
+            Bookings.Clear();
+            foreach (var booking in all)
+            {
+                Bookings.Add(booking);
+            }
+        }
+
+        [RelayCommand]
+        private async Task CancelBooking(Booking booking)
+        {
+            if (booking == null)
+                return;
+
+            booking.Status = "Cancelled";
+            await _bookingRepository.UpdateAsync(booking);
+            LoadBookings();
+        }
+
+        [RelayCommand]
+        private async Task EditBooking(Booking booking)
+        {
+            if (booking == null)
+                return;
+
+            booking.Status = "Modified";
+            await _bookingRepository.UpdateAsync(booking);
+            LoadBookings();
+        }
+    }
+}

--- a/ViewModels/UserViewModel.cs
+++ b/ViewModels/UserViewModel.cs
@@ -379,6 +379,27 @@ namespace Hotel_Booking_System.ViewModels
                 FilterBookingsByUser(CurrentUser.UserID);
             }
         }
+        [RelayCommand]
+        private async Task CancelBooking(Booking booking)
+        {
+            if (booking == null)
+                return;
+
+            booking.Status = "Cancelled";
+            await _bookingRepository.UpdateAsync(booking);
+            FilterBookingsByUser(CurrentUser.UserID);
+        }
+
+        [RelayCommand]
+        private async Task EditBooking(Booking booking)
+        {
+            if (booking == null)
+                return;
+
+            booking.Status = "Modified";
+            await _bookingRepository.UpdateAsync(booking);
+            FilterBookingsByUser(CurrentUser.UserID);
+        }
         private void FilterBookingsByUser(string userId)
         {
             var bookingList = _bookingRepository.GetBookingByUserId(userId).Result;

--- a/Views/AdminWindow.xaml
+++ b/Views/AdminWindow.xaml
@@ -6,7 +6,22 @@
         xmlns:local="clr-namespace:Hotel_Booking_System.Views"
         mc:Ignorable="d"
         Title="AdminWindow" Height="450" Width="800">
-    <Grid>
-        
+    <Grid Margin="10">
+        <ItemsControl ItemsSource="{Binding Bookings}">
+            <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                    <StackPanel Orientation="Horizontal" Margin="0,5">
+                        <TextBlock Text="{Binding BookingID}" Width="150"/>
+                        <TextBlock Text="{Binding Status}" Width="100"/>
+                        <Button Content="Cancel" Width="75" Margin="5,0"
+                                Command="{Binding DataContext.CancelBookingCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                CommandParameter="{Binding}"/>
+                        <Button Content="Edit" Width="75"
+                                Command="{Binding DataContext.EditBookingCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                CommandParameter="{Binding}"/>
+                    </StackPanel>
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
     </Grid>
 </Window>

--- a/Views/AdminWindow.xaml.cs
+++ b/Views/AdminWindow.xaml.cs
@@ -11,6 +11,8 @@ using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
+using Hotel_Booking_System.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Hotel_Booking_System.Views
 {
@@ -19,9 +21,11 @@ namespace Hotel_Booking_System.Views
     /// </summary>
     public partial class AdminWindow : Window
     {
+        IAdminViewModel _adminViewModel = App.Provider.GetRequiredService<IAdminViewModel>();
         public AdminWindow()
         {
             InitializeComponent();
+            DataContext = _adminViewModel;
         }
     }
 }

--- a/Views/UserWindow.xaml
+++ b/Views/UserWindow.xaml
@@ -725,10 +725,11 @@ Stretch="UniformToFill">
 
                                             <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,15,0,0" >
                                                 <Button Content="Cancel" Width="100" Style="{StaticResource SecondaryButton}"
-                        Command="{Binding CancelBookingCommand}" CommandParameter="{Binding}"/>
+                        Command="{Binding DataContext.CancelBookingCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}" CommandParameter="{Binding}"/>
                                                 <Button Content="Review" Width="100" Style="{StaticResource SecondaryButton}"
                         Command="{Binding ReviewBookingCommand}" CommandParameter="{Binding}"/>
-                                                <Button Content="Request changes" Width="120" Style="{StaticResource SecondaryButton}"/>
+                                                <Button Content="Edit" Width="120" Style="{StaticResource SecondaryButton}"
+                        Command="{Binding DataContext.EditBookingCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}" CommandParameter="{Binding}"/>
                                             </StackPanel>
                                         </Grid>
                                     </Border>


### PR DESCRIPTION
## Summary
- enable cancel and edit booking actions through new commands in UserViewModel and AdminViewModel
- wire up admin window with new view model and register dependency
- show cancel and edit buttons in user and admin windows

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c417d195608333be54ed4146fac5dc