### PR TITLE
Add Gemini AI chat service integration

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -2,6 +2,7 @@
 using System.Data;
 using System.Runtime.CompilerServices;
 using System.Windows;
+using System.Net.Http;
 using DotNetEnv;
 using Hotel_Booking_System.Interfaces;
 using Hotel_Booking_System.Repository;
@@ -45,8 +46,14 @@ namespace Hotel_Booking_System
                                  .AddScoped<IReviewRepository, ReviewRepository>()
                                  .AddScoped<IPaymentRepository, PaymentRepository>()
                                  .AddScoped<IAmenityRepository, AmenityRepository>()
-                                 .AddScoped<IAIChatRepository, AIChatRepository>()
+                               .AddScoped<IAIChatRepository, AIChatRepository>()
                                  .AddScoped<IAIChatService, AIChatService>()
+                                 .AddSingleton(new HttpClient())
+                                 .AddSingleton(provider => new GeminiOptions
+                                 {
+                                     ApiKey = Environment.GetEnvironmentVariable("GEMINI_API_KEY") ?? string.Empty,
+                                     DefaultModel = Environment.GetEnvironmentVariable("GEMINI_DEFAULT_MODEL") ?? string.Empty
+                                 })
                                .AddScoped<IRoomRepository, RoomRepository>()
                                .AddScoped<IHotelAdminRequestRepository, HotelAdminRequestRepository>()
 

--- a/Interfaces/IAIChatService.cs
+++ b/Interfaces/IAIChatService.cs
@@ -5,6 +5,6 @@ namespace Hotel_Booking_System.Interfaces
 {
     public interface IAIChatService
     {
-        Task<AIChat> SendAsync(string userId, string message);
+        Task<AIChat> SendAsync(string userId, string message, string model = null);
     }
 }

--- a/Services/GeminiOptions.cs
+++ b/Services/GeminiOptions.cs
@@ -1,0 +1,8 @@
+namespace Hotel_Booking_System.Services
+{
+    public class GeminiOptions
+    {
+        public string ApiKey { get; set; }
+        public string DefaultModel { get; set; }
+    }
+}

--- a/ViewModels/UserViewModel.cs
+++ b/ViewModels/UserViewModel.cs
@@ -45,6 +45,7 @@ namespace Hotel_Booking_System.ViewModels
         private string _loadingVisibility = "Collapsed";
         private string _errorVisibility = "Collapsed";
         private string _errorMessage = string.Empty;
+        private string _selectedModel;
 
         public string ShowSearchRoom { get => _showSearchRoom; set => Set(ref _showSearchRoom, value); }
         public string ShowSearchHotel { get => _showSearchHotel; set => Set(ref _showSearchHotel, value); }
@@ -114,6 +115,7 @@ namespace Hotel_Booking_System.ViewModels
         public string ErrorVisibility { get => _errorVisibility; set => Set(ref _errorVisibility, value); }
         public string ErrorMessage { get => _errorMessage; set => Set(ref _errorMessage, value); }
         public ObservableCollection<AIChat> Chats { get; set; } = new ObservableCollection<AIChat>();
+        public string SelectedModel { get => _selectedModel; set => Set(ref _selectedModel, value); }
 
 
         public UserViewModel(IAIChatService aIChatService , IBookingRepository bookingRepository ,IUserRepository userRepository, IHotelRepository hotelRepository, INavigationService navigationService, IRoomRepository roomRepository, IAuthentication authentication, IHotelAdminRequestRepository hotelAdminRequestRepository)
@@ -319,7 +321,7 @@ namespace Hotel_Booking_System.ViewModels
             ErrorMessage = string.Empty;
             try
             {
-                var chat = await _aiChatService.SendAsync(CurrentUser.UserID, message);
+                var chat = await _aiChatService.SendAsync(CurrentUser.UserID, message, SelectedModel);
                 Chats.Add(chat);
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary
- add GeminiOptions for API key and default model
- configure Gemini options and HttpClient in application startup
- implement Gemini API calls in AIChatService and support optional model selection
- allow UserViewModel to specify model when sending messages

## Testing
- `dotnet build -p:EnableWindowsTargeting=true` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c420c80ad08333beea45ea6d44c160