### PR TITLE
feat: allow hotel admin requests

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -38,6 +38,7 @@ namespace Hotel_Booking_System
                                .AddTransient<UserWindow>()
                                .AddTransient<BookingDialog>()
                                .AddTransient<AdminWindow>()
+                               .AddTransient<SuperAdminWindow>()
 
                                .AddScoped<IHotelRepository, HotelRepository>()
                                .AddSingleton<IBookingRepository, BookingRepository>()
@@ -56,6 +57,7 @@ namespace Hotel_Booking_System
                               .AddScoped<IBookingViewModel, BookingViewModel>()
                               .AddScoped<IForgotPasswordViewModel, ForgotPasswordViewModel>()
                               .AddScoped<ISignUpViewModel, SignUpViewModel>()
+                              .AddScoped<IAdminViewModel, AdminViewModel>()
                               .AddScoped<IUserViewModel, UserViewModel>()
                               .BuildServiceProvider();
         }

--- a/DomainModels/HotelAdminRequest.cs
+++ b/DomainModels/HotelAdminRequest.cs
@@ -14,6 +14,7 @@ namespace Hotel_Booking_System.DomainModels
         public string UserID { get; set; }
         public string HotelName { get; set; }
         public string HotelAddress { get; set; }
+        public string Reason { get; set; }
         public string Status { get; set; }
         public DateTime CreatedAt { get; set; }
     }

--- a/Interfaces/IAdminViewModel.cs
+++ b/Interfaces/IAdminViewModel.cs
@@ -1,0 +1,10 @@
+using System.Collections.ObjectModel;
+using Hotel_Booking_System.DomainModels;
+
+namespace Hotel_Booking_System.Interfaces
+{
+    interface IAdminViewModel
+    {
+        ObservableCollection<HotelAdminRequest> Requests { get; set; }
+    }
+}

--- a/ViewModels/AdminViewModel.cs
+++ b/ViewModels/AdminViewModel.cs
@@ -1,0 +1,60 @@
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.Input;
+using Hotel_Booking_System.DomainModels;
+using Hotel_Booking_System.Interfaces;
+using Hotel_Manager.FrameWorks;
+
+namespace Hotel_Booking_System.ViewModels
+{
+    public partial class AdminViewModel : Bindable, IAdminViewModel
+    {
+        private readonly IHotelAdminRequestRepository _requestRepository;
+        private readonly IUserRepository _userRepository;
+
+        public ObservableCollection<HotelAdminRequest> Requests { get; set; } = new ObservableCollection<HotelAdminRequest>();
+
+        public AdminViewModel(IHotelAdminRequestRepository requestRepository, IUserRepository userRepository)
+        {
+            _requestRepository = requestRepository;
+            _userRepository = userRepository;
+            LoadRequests();
+        }
+
+        private async void LoadRequests()
+        {
+            var list = await _requestRepository.GetAllAsync();
+            Requests.Clear();
+            foreach (var r in list)
+            {
+                Requests.Add(r);
+            }
+        }
+
+        [RelayCommand]
+        private async Task ApproveRequest(string id)
+        {
+            var request = await _requestRepository.GetByIdAsync(id);
+            if (request == null) return;
+            request.Status = "Approved";
+            await _requestRepository.UpdateAsync(request);
+            var user = await _userRepository.GetByIdAsync(request.UserID);
+            if (user != null)
+            {
+                user.Role = "HotelAdmin";
+                await _userRepository.UpdateAsync(user);
+            }
+            LoadRequests();
+        }
+
+        [RelayCommand]
+        private async Task RejectRequest(string id)
+        {
+            var request = await _requestRepository.GetByIdAsync(id);
+            if (request == null) return;
+            request.Status = "Rejected";
+            await _requestRepository.UpdateAsync(request);
+            LoadRequests();
+        }
+    }
+}

--- a/ViewModels/UserViewModel.cs
+++ b/ViewModels/UserViewModel.cs
@@ -42,6 +42,9 @@ namespace Hotel_Booking_System.ViewModels
         private string _showChatButton = "Visible";
         private Hotel _currentHotel;
         private User _currentUser;
+        private string _requestHotelName = "";
+        private string _requestHotelAddress = "";
+        private string _requestReason = "";
 
         public string ShowSearchRoom { get => _showSearchRoom; set => Set(ref _showSearchRoom, value); }
         public string ShowSearchHotel { get => _showSearchHotel; set => Set(ref _showSearchHotel, value); }
@@ -59,6 +62,9 @@ namespace Hotel_Booking_System.ViewModels
         }
         public User CurrentUser { get => _currentUser; set => Set(ref _currentUser, value); }
         public Hotel CurrentHotel { get => _currentHotel; set => Set(ref _currentHotel, value); }
+        public string RequestHotelName { get => _requestHotelName; set => Set(ref _requestHotelName, value); }
+        public string RequestHotelAddress { get => _requestHotelAddress; set => Set(ref _requestHotelAddress, value); }
+        public string RequestReason { get => _requestReason; set => Set(ref _requestReason, value); }
 
         public string ShowChatBox
         {
@@ -332,6 +338,26 @@ namespace Hotel_Booking_System.ViewModels
         {
             ShowRegisterForm = "Collapsed";
         }
+        [RelayCommand]
+        private async Task SubmitRequest()
+        {
+            if (string.IsNullOrWhiteSpace(RequestHotelName) || string.IsNullOrWhiteSpace(RequestHotelAddress) || string.IsNullOrWhiteSpace(RequestReason)) return;
+            var req = new HotelAdminRequest
+            {
+                RequestID = Guid.NewGuid().ToString(),
+                UserID = CurrentUser.UserID,
+                HotelName = RequestHotelName,
+                HotelAddress = RequestHotelAddress,
+                Reason = RequestReason,
+                Status = "Pending",
+                CreatedAt = DateTime.Now
+            };
+            await _hotelAdminRequestRepository.AddAsync(req);
+            await _hotelAdminRequestRepository.SaveAsync();
+            RequestHotelName = RequestHotelAddress = RequestReason = string.Empty;
+            ShowRegisterForm = "Collapsed";
+        }
+
         [RelayCommand]
         private void HideRooms()
         {

--- a/Views/AdminWindow.xaml
+++ b/Views/AdminWindow.xaml
@@ -1,4 +1,4 @@
-﻿<Window x:Class="Hotel_Booking_System.Views.AdminWindow"
+<Window x:Class="Hotel_Booking_System.Views.AdminWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -7,6 +7,28 @@
         mc:Ignorable="d"
         Title="AdminWindow" Height="450" Width="800">
     <Grid>
-        
+        <TabControl>
+            <TabItem Header="Hotel Admin Requests">
+                <DataGrid ItemsSource="{Binding Requests}" AutoGenerateColumns="False" Margin="10">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Request ID" Binding="{Binding RequestID}" Width="*"/>
+                        <DataGridTextColumn Header="User ID" Binding="{Binding UserID}" Width="*"/>
+                        <DataGridTextColumn Header="Hotel Name" Binding="{Binding HotelName}" Width="*"/>
+                        <DataGridTextColumn Header="Reason" Binding="{Binding Reason}" Width="*"/>
+                        <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="*"/>
+                        <DataGridTemplateColumn Header="Actions" Width="200">
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <StackPanel Orientation="Horizontal">
+                                        <Button Content="Approve" Command="{Binding DataContext.ApproveRequestCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="{Binding RequestID}" Margin="2"/>
+                                        <Button Content="Reject" Command="{Binding DataContext.RejectRequestCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="{Binding RequestID}" Margin="2"/>
+                                    </StackPanel>
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
+                    </DataGrid.Columns>
+                </DataGrid>
+            </TabItem>
+        </TabControl>
     </Grid>
 </Window>

--- a/Views/AdminWindow.xaml.cs
+++ b/Views/AdminWindow.xaml.cs
@@ -1,27 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Hotel_Booking_System.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
 
 namespace Hotel_Booking_System.Views
 {
-    /// <summary>
-    /// Interaction logic for AdminWindow.xaml
-    /// </summary>
     public partial class AdminWindow : Window
     {
+        IAdminViewModel _viewModel = App.Provider!.GetRequiredService<IAdminViewModel>();
         public AdminWindow()
         {
             InitializeComponent();
+            DataContext = _viewModel;
         }
     }
 }

--- a/Views/SuperAdminWindow.xaml
+++ b/Views/SuperAdminWindow.xaml
@@ -827,6 +827,27 @@ Margin="50" Padding="0">
 
             </TabItem>
 
+            <TabItem Header="Hotel Admin Requests">
+                <DataGrid ItemsSource="{Binding Requests}" AutoGenerateColumns="False" Margin="30,20">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Request ID" Binding="{Binding RequestID}" Width="*"/>
+                        <DataGridTextColumn Header="User ID" Binding="{Binding UserID}" Width="*"/>
+                        <DataGridTextColumn Header="Hotel Name" Binding="{Binding HotelName}" Width="*"/>
+                          <DataGridTextColumn Header="Reason" Binding="{Binding Reason}" Width="*"/>
+                        <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="*"/>
+                        <DataGridTemplateColumn Header="Actions" Width="200">
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <StackPanel Orientation="Horizontal">
+                                        <Button Content="Approve" Command="{Binding DataContext.ApproveRequestCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="{Binding RequestID}" Margin="2"/>
+                                        <Button Content="Reject" Command="{Binding DataContext.RejectRequestCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="{Binding RequestID}" Margin="2"/>
+                                    </StackPanel>
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
+                    </DataGrid.Columns>
+                </DataGrid>
+            </TabItem>
         </TabControl>
     </Grid>
 </Window>

--- a/Views/SuperAdminWindow.xaml.cs
+++ b/Views/SuperAdminWindow.xaml.cs
@@ -1,27 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Hotel_Booking_System.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
 
 namespace Hotel_Booking_System.Views
 {
-    /// <summary>
-    /// Interaction logic for SuperAdminWindow.xaml
-    /// </summary>
     public partial class SuperAdminWindow : Window
     {
+        IAdminViewModel _viewModel = App.Provider!.GetRequiredService<IAdminViewModel>();
         public SuperAdminWindow()
         {
             InitializeComponent();
+            DataContext = _viewModel;
         }
     }
 }

--- a/Views/UserWindow.xaml
+++ b/Views/UserWindow.xaml
@@ -1028,12 +1028,13 @@ Margin="50" Padding="0">
                                                     <RowDefinition Height="Auto"/>
                                                     <RowDefinition Height="Auto"/>
                                                     <RowDefinition Height="Auto"/>
+                                                      <RowDefinition Height="Auto"/>
                                                 </Grid.RowDefinitions>
 
 
                                                 <StackPanel Grid.Row="0" Grid.ColumnSpan="2">
                                                     <TextBlock Text="Hotel Name *" FontWeight="SemiBold" Margin="0,0,0,5"/>
-                                                    <TextBox x:Name="txtHotelName" Style="{StaticResource ModernTextBox}"
+                                                    <TextBox Text="{Binding RequestHotelName, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ModernTextBox}"
                          />
                                                 </StackPanel>
 
@@ -1052,7 +1053,7 @@ Margin="50" Padding="0">
 
                                                 <StackPanel Grid.Row="2" Grid.ColumnSpan="2" Margin="0,0,0,15">
                                                     <TextBlock Text="Hotel Address *" FontWeight="SemiBold" Margin="0,0,0,5"/>
-                                                    <TextBox x:Name="txtHotelAddress" Style="{StaticResource ModernTextBox}"
+                                                    <TextBox Text="{Binding RequestHotelAddress, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ModernTextBox}"
                         />
                                                 </StackPanel>
 
@@ -1092,6 +1093,10 @@ Margin="50" Padding="0">
                                                     <TextBox x:Name="txtHotelDescription" Style="{StaticResource ModernTextBox}"
                          Height="80" TextWrapping="Wrap" AcceptsReturn="True"
                          VerticalScrollBarVisibility="Auto"/>
+                                                </StackPanel>
+                                                <StackPanel Grid.Row="5" Grid.ColumnSpan="2" Margin="0,0,0,15">
+                                                    <TextBlock Text="Reason *" FontWeight="SemiBold" Margin="0,0,0,5"/>
+                                                    <TextBox Text="{Binding RequestReason, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ModernTextBox}" Height="80" TextWrapping="Wrap" AcceptsReturn="True" VerticalScrollBarVisibility="Auto"/>
                                                 </StackPanel>
                                             </Grid>
 
@@ -1146,7 +1151,7 @@ Margin="50" Padding="0">
                                             <Button Command="{Binding CloseFormCommand}" Content="Cancel" Width="100" Height="40" 
                 Style="{StaticResource SecondaryButton}" 
                 Margin="0,0,10,0"/>
-                                            <Button Content="Submit" Width="150" Height="40" 
+                                            <Button Command="{Binding SubmitRequestCommand}" Content="Submit" Width="150" Height="40" 
                 Style="{StaticResource PrimaryButton}" Background="#FFFF9800"
                 />
                                         </StackPanel>


### PR DESCRIPTION
## Summary
- allow users to submit hotel admin requests with reason and hotel info
- add admin views to review and approve or reject hotel admin requests
- promote users to HotelAdmin upon request approval

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c417d3a5ec8333b38f589db8bebd52