### PR TITLE
Use Mscc Generative AI pattern in AIChatService

### DIFF
--- a/Services/AIChatService.cs
+++ b/Services/AIChatService.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Threading.Tasks;
-using Google.AI.GenerativeAI;
+using Mscc.GenerativeAI;
 using Hotel_Booking_System.DomainModels;
 using Hotel_Booking_System.Interfaces;
 
@@ -24,7 +24,8 @@ namespace Hotel_Booking_System.Services
             if (string.IsNullOrWhiteSpace(message))
                 throw new ArgumentException("Message is required", nameof(message));
 
-            var generativeModel = new GenerativeModel(model ?? _options.DefaultModel, _options.ApiKey);
+            var googleAI = new GoogleAI(apiKey: _options.ApiKey);
+            var generativeModel = googleAI.GenerativeModel(model ?? _options.DefaultModel);
             var result = await generativeModel.GenerateContentAsync(message);
             var response = result.Text ?? string.Empty;
 


### PR DESCRIPTION
## Summary
- switch to `Mscc.GenerativeAI` namespace
- create generative model via `GoogleAI` helper for content generation

## Testing
- `dotnet test` *(fails: NU1101 Unable to find package Google.AI)*

------
https://chatgpt.com/codex/tasks/task_e_68c4307a33a88333a5181556840856b3