### PR TITLE
Refactor SuperAdmin data loading

### DIFF
--- a/Interfaces/ISuperAdminViewModel.cs
+++ b/Interfaces/ISuperAdminViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.Input;
 using Hotel_Booking_System.DomainModels;
 
@@ -10,6 +11,7 @@ namespace Hotel_Booking_System.Interfaces
         int TotalUsers { get; set; }
         int PendingRequests { get; set; }
         ObservableCollection<HotelAdminRequest> PendingRequest { get; set; }
+        Task LoadDataAsync();
 
     }
 }

--- a/ViewModels/SuperAdminViewModel.cs
+++ b/ViewModels/SuperAdminViewModel.cs
@@ -68,16 +68,14 @@ namespace Hotel_Booking_System.ViewModels
             _navigationService = navigationService;
 
             WeakReferenceMessenger.Default.Register<SuperAdminViewModel, MessageService>(this, (recipient, message) =>
-             {
-                  recipient._userEmail = message.Value;
-                 GetCurrentUser();
-                 
-             });
-            LoadDataAsync();
+            {
+                recipient._userEmail = message.Value;
+                GetCurrentUser();
 
+            });
         }
 
-        public async void LoadDataAsync()
+        public async Task LoadDataAsync()
         {
             try
             {
@@ -85,9 +83,9 @@ namespace Hotel_Booking_System.ViewModels
                 TotalHotels = hotels.Count();
                 var users = await _userRepository.GetAllAsync();
                 TotalUsers = users.Count();
-                var requests = _hotelAdminRequestRepository.GetAllAsync().Result.Where(r => r.Status == "Pending").ToList();
+                var requests = (await _hotelAdminRequestRepository.GetAllAsync()).Where(r => r.Status == "Pending").ToList();
                 PendingRequests = requests.Count();
-                
+
                 foreach (var request in requests)
                 {
                     if (!PendingRequest.Any(r => r.RequestID == request.RequestID))

--- a/Views/SuperAdminWindow.xaml.cs
+++ b/Views/SuperAdminWindow.xaml.cs
@@ -27,6 +27,7 @@ namespace Hotel_Booking_System.Views
             Loaded += async (s, e) =>
             {
                 await _paymentViewModel.LoadPaymentsAsync();
+                await _superAdminViewModel.LoadDataAsync();
             };
         }
        


### PR DESCRIPTION
## Summary
- make `LoadDataAsync` an awaited Task returning method
- fetch hotel admin requests asynchronously instead of blocking
- load super admin data on window `Loaded` event

## Testing
- `dotnet build` *(fails: The imported project "Microsoft.NET.Sdk.WindowsDesktop.targets" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4e159d5488333a6a1586da8e76776