### PR TITLE
Fix user avatar binding in chat box

### DIFF
--- a/Views/UserWindow.xaml
+++ b/Views/UserWindow.xaml
@@ -579,7 +579,7 @@
                                                         </Border>
 
                                                         <Grid Grid.Column="1" Width="32" Height="32">
-                                                            <Image Source="{Binding CurrentUser.AvatarUrl, FallbackValue=\Resources\avatar_default.png}"
+                                                            <Image Source="{Binding DataContext.CurrentUser.AvatarUrl, RelativeSource={RelativeSource AncestorType=Window}, FallbackValue=/Resources/avatar_default.png}"
                        Stretch="UniformToFill">
                                                                 <Image.Clip>
                                                                     <EllipseGeometry Center="16,16" RadiusX="16" RadiusY="16"/>


### PR DESCRIPTION
## Summary
- Bind user avatar in chat messages to the window's current user to display the proper avatar with a fallback image

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5487b17948333bd9ab6111cb2e527