### PR TITLE
Add revenue analytics tab for hotel admin

### DIFF
--- a/App.xaml
+++ b/App.xaml
@@ -14,6 +14,7 @@
         <conv:FilterRoomConverter x:Key="FilterRoomConverter"/>
         <conv:TotalAmountCalculatorConverter x:Key="TotalAmountCalculatorConverter"/>
         <conv:RoomIdToRoomNumberConverter x:Key="RoomIdToRoomNumberConverter"/>
+        <conv:RevenueToHeightConverter x:Key="RevenueToHeightConverter"/>
         <conv:HotelIdToHotelNameConverter x:Key="HotelIdToHotelNameConverter"/>
 
         <LinearGradientBrush x:Key="PrimaryGradient" StartPoint="0,0" EndPoint="1,1">

--- a/Converters/RevenueToHeightConverter.cs
+++ b/Converters/RevenueToHeightConverter.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace Hotel_Booking_System.Converters
+{
+    public class RevenueToHeightConverter : IMultiValueConverter
+    {
+        public object Convert(object[] values, Type targetType, object? parameter, CultureInfo culture)
+        {
+            if (values == null || values.Length < 2)
+            {
+                return 0d;
+            }
+
+            if (values[0] is not double amount || values[1] is not double maxAmount)
+            {
+                return 0d;
+            }
+
+            if (maxAmount <= 0)
+            {
+                return 0d;
+            }
+
+            var maxHeight = 120d;
+            if (parameter != null && double.TryParse(parameter.ToString(), NumberStyles.Float, CultureInfo.InvariantCulture, out var parsedHeight))
+            {
+                maxHeight = parsedHeight;
+            }
+
+            var ratio = Math.Max(0, amount / maxAmount);
+            return ratio * maxHeight;
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/Views/HotelAdminWindow.xaml
+++ b/Views/HotelAdminWindow.xaml
@@ -282,7 +282,112 @@
                 </ScrollViewer>
             </TabItem>
 
-            
+
+            <TabItem Style="{StaticResource TabItemStyle}" x:Name="RevenueTab" Header="💰 Doanh thu" Visibility="Visible">
+                <ScrollViewer Margin="30,20" VerticalScrollBarVisibility="Auto">
+                    <StackPanel>
+                        <TextBlock Text="Tổng quan doanh thu" Style="{StaticResource HeaderTextStyle}"/>
+                        <TextBlock Text="Theo dõi doanh thu theo tuần, tháng và năm để nắm bắt xu hướng kinh doanh." Margin="0,8,0,20" Foreground="#FF666666"/>
+
+                        <Border Style="{StaticResource CardStyle}" Margin="0,0,0,20">
+                            <StackPanel Margin="25">
+                                <TextBlock Text="Doanh thu theo tuần" FontSize="18" FontWeight="Bold"/>
+                                <TextBlock Text="{Binding WeeklyRevenueTotal, StringFormat='Tổng (7 ngày): {0:N0} ₫'}" Margin="0,4,0,16" Foreground="#FF424242"/>
+                                <ItemsControl ItemsSource="{Binding WeeklyRevenue}">
+                                    <ItemsControl.ItemsPanel>
+                                        <ItemsPanelTemplate>
+                                            <UniformGrid Columns="7"/>
+                                        </ItemsPanelTemplate>
+                                    </ItemsControl.ItemsPanel>
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate>
+                                            <StackPanel Margin="5" VerticalAlignment="Bottom" HorizontalAlignment="Center">
+                                                <TextBlock Text="{Binding Amount, StringFormat='{}{0:N0} ₫'}" FontSize="12" HorizontalAlignment="Center" Foreground="#FF666666"/>
+                                                <Border Width="32" Height="140" Background="#FFE3F2FD" Margin="0,6,0,6" CornerRadius="12" Padding="4" SnapsToDevicePixels="True">
+                                                    <Border Background="#FF1976D2" CornerRadius="8,8,0,0" HorizontalAlignment="Stretch" VerticalAlignment="Bottom">
+                                                        <Border.Height>
+                                                            <MultiBinding Converter="{StaticResource RevenueToHeightConverter}" ConverterParameter="132">
+                                                                <Binding Path="Amount"/>
+                                                                <Binding Path="DataContext.MaxWeeklyRevenue" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
+                                                            </MultiBinding>
+                                                        </Border.Height>
+                                                    </Border>
+                                                </Border>
+                                                <TextBlock Text="{Binding Label}" FontSize="12" HorizontalAlignment="Center" Foreground="#FF424242"/>
+                                            </StackPanel>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </StackPanel>
+                        </Border>
+
+                        <Border Style="{StaticResource CardStyle}" Margin="0,0,0,20">
+                            <StackPanel Margin="25">
+                                <TextBlock Text="Doanh thu theo tháng" FontSize="18" FontWeight="Bold"/>
+                                <TextBlock Text="{Binding MonthlyRevenueTotal, StringFormat='Tổng (6 tháng): {0:N0} ₫'}" Margin="0,4,0,16" Foreground="#FF424242"/>
+                                <ItemsControl ItemsSource="{Binding MonthlyRevenue}">
+                                    <ItemsControl.ItemsPanel>
+                                        <ItemsPanelTemplate>
+                                            <UniformGrid Columns="6"/>
+                                        </ItemsPanelTemplate>
+                                    </ItemsControl.ItemsPanel>
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate>
+                                            <StackPanel Margin="5" VerticalAlignment="Bottom" HorizontalAlignment="Center">
+                                                <TextBlock Text="{Binding Amount, StringFormat='{}{0:N0} ₫'}" FontSize="12" HorizontalAlignment="Center" Foreground="#FF666666"/>
+                                                <Border Width="36" Height="160" Background="#FFFFF3E0" Margin="0,6,0,6" CornerRadius="12" Padding="4" SnapsToDevicePixels="True">
+                                                    <Border Background="#FFFF9800" CornerRadius="8,8,0,0" HorizontalAlignment="Stretch" VerticalAlignment="Bottom">
+                                                        <Border.Height>
+                                                            <MultiBinding Converter="{StaticResource RevenueToHeightConverter}" ConverterParameter="152">
+                                                                <Binding Path="Amount"/>
+                                                                <Binding Path="DataContext.MaxMonthlyRevenue" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
+                                                            </MultiBinding>
+                                                        </Border.Height>
+                                                    </Border>
+                                                </Border>
+                                                <TextBlock Text="{Binding Label}" FontSize="12" HorizontalAlignment="Center" Foreground="#FF424242"/>
+                                            </StackPanel>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </StackPanel>
+                        </Border>
+
+                        <Border Style="{StaticResource CardStyle}">
+                            <StackPanel Margin="25">
+                                <TextBlock Text="Doanh thu theo năm" FontSize="18" FontWeight="Bold"/>
+                                <TextBlock Text="{Binding YearlyRevenueTotal, StringFormat='Tổng (5 năm): {0:N0} ₫'}" Margin="0,4,0,16" Foreground="#FF424242"/>
+                                <ItemsControl ItemsSource="{Binding YearlyRevenue}">
+                                    <ItemsControl.ItemsPanel>
+                                        <ItemsPanelTemplate>
+                                            <UniformGrid Columns="5"/>
+                                        </ItemsPanelTemplate>
+                                    </ItemsControl.ItemsPanel>
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate>
+                                            <StackPanel Margin="5" VerticalAlignment="Bottom" HorizontalAlignment="Center">
+                                                <TextBlock Text="{Binding Amount, StringFormat='{}{0:N0} ₫'}" FontSize="12" HorizontalAlignment="Center" Foreground="#FF666666"/>
+                                                <Border Width="40" Height="160" Background="#FFE8F5E9" Margin="0,6,0,6" CornerRadius="12" Padding="4" SnapsToDevicePixels="True">
+                                                    <Border Background="#FF2E7D32" CornerRadius="8,8,0,0" HorizontalAlignment="Stretch" VerticalAlignment="Bottom">
+                                                        <Border.Height>
+                                                            <MultiBinding Converter="{StaticResource RevenueToHeightConverter}" ConverterParameter="152">
+                                                                <Binding Path="Amount"/>
+                                                                <Binding Path="DataContext.MaxYearlyRevenue" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
+                                                            </MultiBinding>
+                                                        </Border.Height>
+                                                    </Border>
+                                                </Border>
+                                                <TextBlock Text="{Binding Label}" FontSize="12" HorizontalAlignment="Center" Foreground="#FF424242"/>
+                                            </StackPanel>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </StackPanel>
+                        </Border>
+                    </StackPanel>
+                </ScrollViewer>
+            </TabItem>
+
             <TabItem Style="{StaticResource TabItemStyle}" x:Name="ReviewsTab" Header="⭐ Reviews" Visibility="Visible">
                 <ScrollViewer Margin="30,20" VerticalScrollBarVisibility="Auto">
                     <StackPanel>


### PR DESCRIPTION
## Summary
- add a Doanh thu tab to the hotel admin dashboard with weekly, monthly, and yearly revenue bar charts
- extend the hotel admin view model to compute revenue aggregates and expose collections for chart binding
- introduce a reusable converter for scaling revenue bar heights and register it in the application resources

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ce07a9cc24833388df10d66325e4d3