### PR TITLE
Remove reason field from hotel admin registration

### DIFF
--- a/ViewModels/UserViewModel.cs
+++ b/ViewModels/UserViewModel.cs
@@ -51,7 +51,6 @@ namespace Hotel_Booking_System.ViewModels
         private string _errorMessage = string.Empty;
         private string _requestHotelName = "";
         private string _requestHotelAddress = "";
-        private string _requestReason = "";
         private string _selectedModel = string.Empty;
         private string _chatInput = string.Empty;
         private string _membershipLevel = "Bronze";
@@ -99,7 +98,6 @@ namespace Hotel_Booking_System.ViewModels
         public Hotel CurrentHotel { get => _currentHotel; set => Set(ref _currentHotel, value); }
         public string RequestHotelName { get => _requestHotelName; set => Set(ref _requestHotelName, value); }
         public string RequestHotelAddress { get => _requestHotelAddress; set => Set(ref _requestHotelAddress, value); }
-        public string RequestReason { get => _requestReason; set => Set(ref _requestReason, value); }
 
         public string ShowChatBox
         {
@@ -630,20 +628,19 @@ namespace Hotel_Booking_System.ViewModels
         [RelayCommand]
         private async Task SubmitRequest()
         {
-            if (string.IsNullOrWhiteSpace(RequestHotelName) || string.IsNullOrWhiteSpace(RequestHotelAddress) || string.IsNullOrWhiteSpace(RequestReason)) return;
+            if (string.IsNullOrWhiteSpace(RequestHotelName) || string.IsNullOrWhiteSpace(RequestHotelAddress)) return;
             var req = new HotelAdminRequest
             {
                 RequestID = Guid.NewGuid().ToString(),
                 UserID = CurrentUser.UserID,
                 HotelName = RequestHotelName,
                 HotelAddress = RequestHotelAddress,
-                Reason = RequestReason,
                 Status = "Pending",
                 CreatedAt = DateTime.Now
             };
             await _hotelAdminRequestRepository.AddAsync(req);
             await _hotelAdminRequestRepository.SaveAsync();
-            RequestHotelName = RequestHotelAddress = RequestReason = string.Empty;
+            RequestHotelName = RequestHotelAddress = string.Empty;
             ShowRegisterForm = "Collapsed";
         }
 

--- a/Views/UserWindow.xaml
+++ b/Views/UserWindow.xaml
@@ -1212,10 +1212,6 @@ Margin="50" Padding="0">
                          Height="80" TextWrapping="Wrap" AcceptsReturn="True"
                          VerticalScrollBarVisibility="Auto"/>
                                                 </StackPanel>
-                                                <StackPanel Grid.Row="5" Grid.ColumnSpan="2" Margin="0,0,0,15">
-                                                    <TextBlock Text="Reason *" FontWeight="SemiBold" Margin="0,0,0,5"/>
-                                                    <TextBox Text="{Binding RequestReason, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ModernTextBox}" Height="80" TextWrapping="Wrap" AcceptsReturn="True" VerticalScrollBarVisibility="Auto"/>
-                                                </StackPanel>
                                             </Grid>
 
 


### PR DESCRIPTION
## Summary
- remove the reason input from the hotel admin registration form
- simplify request submission logic to only require hotel name and address when registering an admin

## Testing
- `dotnet build` *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d22b63b9a4833386e2196c3abd224b