### PR TITLE
Remove admin bookings tab from super admin view

### DIFF
--- a/Views/SuperAdminWindow.xaml
+++ b/Views/SuperAdminWindow.xaml
@@ -695,52 +695,6 @@
             </TabItem>
 
 
-            <TabItem x:Name="AdminBookingsRequestsTab" Header="Admin Bookings &amp; Requests">
-                <Grid Margin="30,20">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="*"/>
-                    </Grid.RowDefinitions>
-
-                    <ItemsControl ItemsSource="{Binding Bookings}">
-                        <ItemsControl.ItemTemplate>
-                            <DataTemplate>
-                                <StackPanel Orientation="Horizontal" Margin="0,5">
-                                    <TextBlock Text="{Binding BookingID}" Width="150"/>
-                                    <TextBlock Text="{Binding Status}" Width="100"/>
-                                    <Button Content="Cancel" Width="75" Margin="5,0"
-                                            Command="{Binding DataContext.CancelBookingCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
-                                            CommandParameter="{Binding}"/>
-                                    <Button Content="Edit" Width="75"
-                                            Command="{Binding DataContext.EditBookingCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
-                                            CommandParameter="{Binding}"/>
-                                </StackPanel>
-                            </DataTemplate>
-                        </ItemsControl.ItemTemplate>
-                    </ItemsControl>
-
-                    <DataGrid Grid.Row="1" ItemsSource="{Binding Requests}" AutoGenerateColumns="False" Margin="0,10,0,0">
-                        <DataGrid.Columns>
-                            <DataGridTextColumn Header="Request ID" Binding="{Binding RequestID}" Width="*"/>
-                            <DataGridTextColumn Header="User ID" Binding="{Binding UserID}" Width="*"/>
-                            <DataGridTextColumn Header="Hotel Name" Binding="{Binding HotelName}" Width="*"/>
-                            <DataGridTextColumn Header="Reason" Binding="{Binding Reason}" Width="*"/>
-                            <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="*"/>
-                            <DataGridTemplateColumn Header="Actions" Width="200">
-                                <DataGridTemplateColumn.CellTemplate>
-                                    <DataTemplate>
-                                        <StackPanel Orientation="Horizontal">
-                                            <Button Content="Approve" Command="{Binding DataContext.ApproveRequestCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}" CommandParameter="{Binding RequestID}" Margin="2"/>
-                                            <Button Content="Reject" Command="{Binding DataContext.RejectRequestCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}" CommandParameter="{Binding RequestID}" Margin="2"/>
-                                        </StackPanel>
-                                    </DataTemplate>
-                                </DataGridTemplateColumn.CellTemplate>
-                            </DataGridTemplateColumn>
-                        </DataGrid.Columns>
-                    </DataGrid>
-                </Grid>
-            </TabItem>
-
         </TabControl>
     </Grid>
 </Window>

--- a/Views/SuperAdminWindow.xaml.cs
+++ b/Views/SuperAdminWindow.xaml.cs
@@ -15,7 +15,6 @@ namespace Hotel_Booking_System.Views
     public partial class SuperAdminWindow : Window
     {
         private readonly IPaymentViewModel _paymentViewModel = App.Provider.GetRequiredService<IPaymentViewModel>();
-        private readonly IAdminViewModel _adminViewModel = App.Provider.GetRequiredService<IAdminViewModel>();
         private readonly ISuperAdminViewModel _superAdminViewModel = App.Provider.GetRequiredService<ISuperAdminViewModel>();
 
         public SuperAdminWindow()
@@ -23,7 +22,6 @@ namespace Hotel_Booking_System.Views
             InitializeComponent();
             DataContext = _superAdminViewModel;
             PaymentSummaryTab.DataContext = _paymentViewModel;
-            AdminBookingsRequestsTab.DataContext = _adminViewModel;
             Loaded += async (s, e) =>
             {
                 await _paymentViewModel.LoadPaymentsAsync();


### PR DESCRIPTION
## Summary
- remove the Admin Bookings & Requests tab from the SuperAdmin window layout
- drop the unused admin view model wiring from the SuperAdminWindow code-behind

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d22d74b3988333b3e580c93782e0a6