### PR TITLE
Remove pending filter option in super admin hotel management

### DIFF
--- a/Views/SuperAdminWindow.xaml
+++ b/Views/SuperAdminWindow.xaml
@@ -212,8 +212,6 @@
                                         Command="{Binding SetHotelStatusFilterCommand}" CommandParameter="All"/>
                                 <Button Content="Active" Background="#FF4CAF50" Style="{StaticResource PrimaryButton}" Width="80"
                                         Command="{Binding SetHotelStatusFilterCommand}" CommandParameter="Active" Margin="10,0,0,0"/>
-                                <Button Content="Pending" Background="#FFFF9800" Style="{StaticResource PrimaryButton}" Width="80"
-                                        Command="{Binding SetHotelStatusFilterCommand}" CommandParameter="Pending" Margin="10,0,0,0"/>
                                 <Button Content="Suspended" Background="#FFFF5722" Style="{StaticResource PrimaryButton}" Width="100"
                                         Command="{Binding SetHotelStatusFilterCommand}" CommandParameter="Suspended" Margin="10,0,0,0"/>
                                 <ComboBox Style="{StaticResource ModernComboBox}" Width="160" Margin="10,0,0,0"


### PR DESCRIPTION
## Summary
- remove the Pending filter button from the Super Admin Hotel Management tab so only All, Active, and Suspended remain

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2488a44388333869fd90545f0d992