### PR TITLE
Remove hotel admin registration from super admin profile

### DIFF
--- a/Views/SuperAdminWindow.xaml
+++ b/Views/SuperAdminWindow.xaml
@@ -535,9 +535,7 @@
                                     </Grid>
 
                                     <StackPanel Orientation="Horizontal" Margin="0,15,0,0">
-                                        <Button Command="{Binding UpdateInfoCommand}" Content="Update Profile" Width="150" Style="{StaticResource PrimaryButton}" Margin="0,0,10,0"/>
-                                        <Button Command="{Binding RegisterCommand}" Content="Register Hotel Admin" Background="#FFFF9800" 
-                                    Style="{StaticResource PrimaryButton}" Width="200"/>
+                                        <Button Command="{Binding UpdateInfoCommand}" Content="Update Profile" Width="150" Style="{StaticResource PrimaryButton}"/>
                                     </StackPanel>
                                 </StackPanel>
                             </Border>
@@ -593,9 +591,9 @@
                                     </Grid>
 
                                     <StackPanel Orientation="Horizontal" Margin="0,15,0,0">
-                                        <Button Content="Change Password" Width="150" Style="{StaticResource PrimaryButton}" 
+                                        <Button Command="{Binding ChangePasswordCommand}" Content="Change Password" Width="150" Style="{StaticResource PrimaryButton}"
                                     Background="#FFFF5722" Margin="0,0,10,0"/>
-                                        <Button Content="Cancel" Width="100" Style="{StaticResource SecondaryButton}"/>
+                                        <Button x:Name="btnCancelPassword" Content="Cancel" Width="100" Style="{StaticResource SecondaryButton}" Click="CancelPassword_Click"/>
                                     </StackPanel>
                                 </StackPanel>
                             </Border>

--- a/Views/SuperAdminWindow.xaml.cs
+++ b/Views/SuperAdminWindow.xaml.cs
@@ -1,13 +1,9 @@
+using System.ComponentModel;
 using Hotel_Booking_System.Interfaces;
+using Hotel_Booking_System.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
 
 
 namespace Hotel_Booking_System.Views
@@ -22,13 +18,70 @@ namespace Hotel_Booking_System.Views
             InitializeComponent();
             DataContext = _superAdminViewModel;
             PaymentSummaryTab.DataContext = _paymentViewModel;
+
+            txtCurrentPassword.PasswordChanged += (s, e) =>
+            {
+                (_superAdminViewModel as dynamic).CurrentPassword = txtCurrentPassword.Password;
+            };
+
+            txtNewPassword.PasswordChanged += (s, e) =>
+            {
+                (_superAdminViewModel as dynamic).NewPassword = txtNewPassword.Password;
+            };
+
+            txtConfirmPassword.PasswordChanged += (s, e) =>
+            {
+                (_superAdminViewModel as dynamic).ConfirmPassword = txtConfirmPassword.Password;
+            };
+
+            if (_superAdminViewModel is INotifyPropertyChanged notifier)
+            {
+                notifier.PropertyChanged += SuperAdminViewModel_PropertyChanged;
+            }
+
             Loaded += async (s, e) =>
             {
                 await _paymentViewModel.LoadPaymentsAsync();
                 await _superAdminViewModel.LoadDataAsync();
             };
         }
-       
-     
+
+        private void SuperAdminViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (_superAdminViewModel is not SuperAdminViewModel vm)
+            {
+                return;
+            }
+
+            if (e.PropertyName == nameof(SuperAdminViewModel.CurrentPassword) && string.IsNullOrEmpty(vm.CurrentPassword))
+            {
+                txtCurrentPassword.Password = string.Empty;
+            }
+
+            if (e.PropertyName == nameof(SuperAdminViewModel.NewPassword) && string.IsNullOrEmpty(vm.NewPassword))
+            {
+                txtNewPassword.Password = string.Empty;
+            }
+
+            if (e.PropertyName == nameof(SuperAdminViewModel.ConfirmPassword) && string.IsNullOrEmpty(vm.ConfirmPassword))
+            {
+                txtConfirmPassword.Password = string.Empty;
+            }
+        }
+
+        private void CancelPassword_Click(object sender, RoutedEventArgs e)
+        {
+            txtCurrentPassword.Password = string.Empty;
+            txtNewPassword.Password = string.Empty;
+            txtConfirmPassword.Password = string.Empty;
+
+            var command = (_superAdminViewModel as dynamic).ClearPasswordFieldsCommand;
+            if (command is ICommand clearCommand && clearCommand.CanExecute(null))
+            {
+                clearCommand.Execute(null);
+            }
+        }
+
+
     }
 }


### PR DESCRIPTION
## Summary
- enhance the super admin view model with profile metrics plus commands for updating details, changing passwords, and uploading avatars
- remove the register hotel admin dialog, related DI registration, and profile tab entry per updated requirements
- wire the super admin window password fields to the view model and add cancel handling

## Testing
- dotnet build *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d253a72e9c83338da726a7e4900a09