### PR TITLE
Add inline notifications for profile management actions

### DIFF
--- a/ViewModels/UserViewModel.cs
+++ b/ViewModels/UserViewModel.cs
@@ -661,20 +661,43 @@ namespace Hotel_Booking_System.ViewModels
 
             if (openFileDialog.ShowDialog() == true)
             {
-                CurrentUser.AvatarUrl = await UploadImageService.UploadAsync(openFileDialog.FileName);
+                try
+                {
+                    CurrentUser.AvatarUrl = await UploadImageService.UploadAsync(openFileDialog.FileName);
+                    await _userRepository.UpdateAsync(CurrentUser);
+                    var refreshed = await _userRepository.GetByIdAsync(CurrentUser.UserID);
+                    if (refreshed != null)
+                    {
+                        CurrentUser = refreshed;
+                    }
+
+                    ShowNotification("Profile image updated successfully.");
+                }
+                catch (Exception)
+                {
+                    ShowNotification("Failed to update profile image. Please try again.");
+                }
+            }
+        }
+
+        [RelayCommand]
+        private async Task UpdateInfo()
+        {
+            try
+            {
                 await _userRepository.UpdateAsync(CurrentUser);
                 var refreshed = await _userRepository.GetByIdAsync(CurrentUser.UserID);
                 if (refreshed != null)
                 {
                     CurrentUser = refreshed;
                 }
-            }
-        }
 
-        [RelayCommand]
-        private void UpdateInfo()
-        {
-            _userRepository.UpdateAsync(CurrentUser);
+                ShowNotification("Profile information updated successfully.");
+            }
+            catch (Exception)
+            {
+                ShowNotification("Failed to update profile information. Please try again.");
+            }
 
         }
         [RelayCommand]

--- a/Views/SuperAdminWindow.xaml
+++ b/Views/SuperAdminWindow.xaml
@@ -459,6 +459,11 @@
 
 
                         <StackPanel Grid.Column="0" Margin="0,0,30,0">
+                            <TextBlock Text="{Binding NotificationMessage}"
+                                       Foreground="Red"
+                                       FontSize="14"
+                                       HorizontalAlignment="Center"
+                                       Margin="0,0,0,10"/>
 
 
                             <Border Style="{StaticResource CardStyle}" Margin="0,0,0,20">


### PR DESCRIPTION
## Summary
- surface inline notifications in the user profile view model when updating the avatar or profile information fails or succeeds
- add notification support to the super admin profile workflows and route change password validation feedback through the shared banner
- expose the notification banner within the super admin profile tab UI

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d263017a608333b05ecff3541af91a