### PR TITLE
Add city selection to hotel admin editor

### DIFF
--- a/ViewModels/HotelAdminViewModel.cs
+++ b/ViewModels/HotelAdminViewModel.cs
@@ -54,6 +54,7 @@ namespace Hotel_Booking_System.ViewModels
         private DispatcherTimer? _notificationTimer;
 
         public ObservableCollection<Hotel> Hotels { get; } = new();
+        public ObservableCollection<string> CityOptions { get; } = new();
         public Hotel? CurrentHotel
         {
             get => _currentHotel;
@@ -61,6 +62,7 @@ namespace Hotel_Booking_System.ViewModels
             {
                 Set(ref _currentHotel, value);
 
+                EnsureCityInOptions(_currentHotel?.City);
                 SyncAmenitiesFromHotel();
                 LoadRooms();
                 LoadBookings();
@@ -414,6 +416,8 @@ namespace Hotel_Booking_System.ViewModels
             _navigationService = navigationService;
             _authenticationService = authenticationService;
 
+            InitializeCityOptions();
+
             RevenueFilterOptions.Add(new RevenueFilterOption { DisplayName = "Theo tuần", Range = RevenueRange.Weekly });
             RevenueFilterOptions.Add(new RevenueFilterOption { DisplayName = "Theo tháng", Range = RevenueRange.Monthly });
             RevenueFilterOptions.Add(new RevenueFilterOption { DisplayName = "Theo năm", Range = RevenueRange.Yearly });
@@ -424,6 +428,41 @@ namespace Hotel_Booking_System.ViewModels
                 recipient._userEmail = message.Value;
                 recipient.LoadCurrentUser();
             });
+        }
+
+        private static readonly string[] DefaultCityOptions = new[]
+        {
+            "Hà Nội",
+            "Tuyên Quang",
+            "Lào Cai",
+            "Thái Nguyên",
+            "Phú Thọ",
+            "Bắc Ninh",
+            "Hưng Yên",
+            "Hải Phòng",
+            "Ninh Bình",
+            "Quảng Trị",
+            "Đà Nẵng",
+            "Quảng Ngãi",
+            "Gia Lai",
+            "Khánh Hòa",
+            "Lâm Đồng",
+            "Đăk Lăk",
+            "TP. Hồ Chí Minh",
+            "TP. Cần Thơ",
+            "Vĩnh Long",
+            "Đồng Tháp",
+            "Cà Mau",
+            "An Giang"
+        };
+
+        private void InitializeCityOptions()
+        {
+            CityOptions.Clear();
+            foreach (var city in DefaultCityOptions)
+            {
+                CityOptions.Add(city);
+            }
         }
 
         private async void LoadCurrentUser()
@@ -446,6 +485,7 @@ namespace Hotel_Booking_System.ViewModels
             foreach (var hotel in hotels.Where(h => h.UserID == CurrentUser.UserID && h.IsApproved))
             {
                 Hotels.Add(hotel);
+                EnsureCityInOptions(hotel.City);
             }
 
             CurrentHotel = Hotels.FirstOrDefault();
@@ -1264,6 +1304,7 @@ namespace Hotel_Booking_System.ViewModels
 
             if (string.IsNullOrWhiteSpace(CurrentHotel.HotelName) ||
                 string.IsNullOrWhiteSpace(CurrentHotel.Address) ||
+                string.IsNullOrWhiteSpace(CurrentHotel.City) ||
                 CurrentHotel.Rating < 1 || CurrentHotel.Rating > 5)
             {
                 return;
@@ -1281,6 +1322,7 @@ namespace Hotel_Booking_System.ViewModels
             }
             else
             {
+                EnsureCityInOptions(CurrentHotel.City);
                 await _hotelRepository.UpdateAsync(CurrentHotel);
             }
         }
@@ -1389,6 +1431,19 @@ namespace Hotel_Booking_System.ViewModels
                 booking.Status = "Cancelled";
                 await _bookingRepository.UpdateAsync(booking);
                 LoadBookings();
+            }
+        }
+
+        private void EnsureCityInOptions(string? city)
+        {
+            if (string.IsNullOrWhiteSpace(city))
+            {
+                return;
+            }
+
+            if (!CityOptions.Contains(city))
+            {
+                CityOptions.Add(city);
             }
         }
     }

--- a/Views/HotelAdminWindow.xaml
+++ b/Views/HotelAdminWindow.xaml
@@ -106,6 +106,7 @@
                                         <RowDefinition Height="Auto"/>
                                         <RowDefinition Height="Auto"/>
                                         <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
                                     </Grid.RowDefinitions>
 
                                     <StackPanel Grid.Row="0" Grid.Column="0" Margin="0,0,15,15">
@@ -128,17 +129,24 @@
 
                                     <StackPanel Grid.Row="1" Grid.ColumnSpan="2" Margin="0,0,0,15">
                                         <TextBlock Text="Address" FontWeight="SemiBold" Margin="0,0,0,5"/>
-                                        <TextBox Text="{Binding CurrentHotel.Address}" 
+                                        <TextBox Text="{Binding CurrentHotel.Address}"
                                             Style="{StaticResource ModernTextBox}"/>
                                     </StackPanel>
 
                                     <StackPanel Grid.Row="2" Grid.ColumnSpan="2" Margin="0,0,0,15">
-                                        <TextBlock Text="Description" FontWeight="SemiBold" Margin="0,0,0,5"/>
-                                        <TextBox Style="{StaticResource ModernTextBox}" Text="{Binding CurrentHotel.Description}" 
-                                            Height="80" TextWrapping="Wrap" AcceptsReturn="True" VerticalScrollBarVisibility="Auto"/>
+                                        <TextBlock Text="City" FontWeight="SemiBold" Margin="0,0,0,5"/>
+                                        <ComboBox Style="{StaticResource ModernComboBox}"
+                                                  ItemsSource="{Binding CityOptions}"
+                                                  SelectedItem="{Binding CurrentHotel.City, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
                                     </StackPanel>
 
                                     <StackPanel Grid.Row="3" Grid.ColumnSpan="2" Margin="0,0,0,15">
+                                        <TextBlock Text="Description" FontWeight="SemiBold" Margin="0,0,0,5"/>
+                                        <TextBox Style="{StaticResource ModernTextBox}" Text="{Binding CurrentHotel.Description}"
+                                            Height="80" TextWrapping="Wrap" AcceptsReturn="True" VerticalScrollBarVisibility="Auto"/>
+                                    </StackPanel>
+
+                                    <StackPanel Grid.Row="4" Grid.ColumnSpan="2" Margin="0,0,0,15">
                                         <TextBlock Text="Amenities" FontWeight="SemiBold" Margin="0,0,0,10"/>
                                         <WrapPanel>
                                             <CheckBox Content="🌐 Free WiFi" Margin="0,0,15,5"
@@ -153,7 +161,7 @@
                                                       IsChecked="{Binding HasGym, Mode=TwoWay}"/>
                                         </WrapPanel>
                                     </StackPanel>
-                                                                    <StackPanel Grid.Row="4" Grid.ColumnSpan="2" Margin="0,0,0,15">
+                                                                    <StackPanel Grid.Row="5" Grid.ColumnSpan="2" Margin="0,0,0,15">
                                         <CheckBox Content="Visible to users" IsChecked="{Binding CurrentHotel.IsVisible}" />
                                     </StackPanel>
                                 </Grid>


### PR DESCRIPTION
## Summary
- expose a reusable list of Vietnamese cities in the hotel admin view model and ensure hotels use it
- populate the hotel admin editor with a city combo box bound to the current hotel
- validate that hotels have a selected city before saving and keep custom cities in the list

## Testing
- `dotnet build` *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db3327a6508333b22cf1f836ace549