### PR TITLE
Enhance super admin management tools

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -55,6 +55,8 @@ namespace Hotel_Booking_System
                 .AddTransient<EditRoomDialog>()
                 .AddTransient<AddRoomDialog>()
                 .AddTransient<AddHotelDialog>()
+                .AddTransient<EditHotelDialog>()
+                .AddTransient<EditUserDialog>()
                 .AddTransient<HotelAdminWindow>()
                 .AddScoped<IHotelRepository, HotelRepository>()
                 .AddSingleton<IBookingRepository, BookingRepository>()

--- a/Interfaces/ISuperAdminViewModel.cs
+++ b/Interfaces/ISuperAdminViewModel.cs
@@ -1,6 +1,5 @@
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
-using CommunityToolkit.Mvvm.Input;
 using Hotel_Booking_System.DomainModels;
 
 namespace Hotel_Booking_System.Interfaces
@@ -16,6 +15,10 @@ namespace Hotel_Booking_System.Interfaces
         double MonthlyRevenue { get; set; }
         ObservableCollection<HotelAdminRequest> PendingRequest { get; set; }
         ObservableCollection<Hotel> PendingHotels { get; set; }
+        ObservableCollection<Hotel> FilteredHotels { get; }
+        ObservableCollection<User> Users { get; set; }
+        ObservableCollection<string> CityOptions { get; }
+        string HotelCountText { get; set; }
         Task LoadDataAsync();
 
     }

--- a/Views/EditHotelDialog.xaml
+++ b/Views/EditHotelDialog.xaml
@@ -1,0 +1,104 @@
+<Window x:Class="Hotel_Booking_System.Views.EditHotelDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Edit Hotel"
+        Height="450"
+        Width="520"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        Background="#FFF8F9FA">
+    <Grid Margin="20">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock Text="Update hotel information"
+                   FontSize="20"
+                   FontWeight="Bold"
+                   Foreground="#FF1976D2"/>
+
+        <StackPanel Grid.Row="1" Margin="0,20,0,0">
+            <StackPanel Margin="0,0,0,12">
+                <TextBlock Text="Hotel name" FontWeight="SemiBold" Margin="0,0,0,4"/>
+                <TextBox Text="{Binding HotelName, UpdateSourceTrigger=PropertyChanged}"/>
+            </StackPanel>
+
+            <StackPanel Margin="0,0,0,12">
+                <TextBlock Text="City" FontWeight="SemiBold" Margin="0,0,0,4"/>
+                <TextBox Text="{Binding City, UpdateSourceTrigger=PropertyChanged}"/>
+            </StackPanel>
+
+            <StackPanel Margin="0,0,0,12">
+                <TextBlock Text="Address" FontWeight="SemiBold" Margin="0,0,0,4"/>
+                <TextBox Text="{Binding Address, UpdateSourceTrigger=PropertyChanged}"/>
+            </StackPanel>
+
+            <StackPanel Margin="0,0,0,12">
+                <TextBlock Text="Description" FontWeight="SemiBold" Margin="0,0,0,4"/>
+                <TextBox Text="{Binding Description, UpdateSourceTrigger=PropertyChanged}" TextWrapping="Wrap" AcceptsReturn="True" Height="80"/>
+            </StackPanel>
+
+            <Grid Margin="0,0,0,12">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+
+                <StackPanel Grid.Column="0" Margin="0,0,10,0">
+                    <TextBlock Text="Minimum price" FontWeight="SemiBold" Margin="0,0,0,4"/>
+                    <TextBox Text="{Binding MinPrice, StringFormat={}{0:F2}, UpdateSourceTrigger=PropertyChanged}"/>
+                </StackPanel>
+
+                <StackPanel Grid.Column="1">
+                    <TextBlock Text="Maximum price" FontWeight="SemiBold" Margin="0,0,0,4"/>
+                    <TextBox Text="{Binding MaxPrice, StringFormat={}{0:F2}, UpdateSourceTrigger=PropertyChanged}"/>
+                </StackPanel>
+            </Grid>
+
+            <Grid Margin="0,0,0,12">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+
+                <StackPanel Grid.Column="0" Margin="0,0,10,0">
+                    <TextBlock Text="Rating" FontWeight="SemiBold" Margin="0,0,0,4"/>
+                    <Slider Minimum="0" Maximum="5" TickFrequency="1" IsSnapToTickEnabled="True"
+                            Value="{Binding Rating, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                </StackPanel>
+
+                <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Bottom">
+                    <TextBlock Text="Visible" FontWeight="SemiBold" Margin="0,0,8,0" VerticalAlignment="Center"/>
+                    <ToggleButton IsChecked="{Binding IsVisible, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="50" Height="24">
+                        <ToggleButton.Template>
+                            <ControlTemplate TargetType="ToggleButton">
+                                <Border Width="50" Height="24" CornerRadius="12" Background="{TemplateBinding Background}">
+                                    <Grid>
+                                        <Ellipse x:Name="Thumb" Width="20" Height="20" Margin="2" Fill="White" HorizontalAlignment="Left"/>
+                                    </Grid>
+                                </Border>
+                                <ControlTemplate.Triggers>
+                                    <Trigger Property="IsChecked" Value="True">
+                                        <Setter Property="Background" Value="#FF4CAF50"/>
+                                        <Setter TargetName="Thumb" Property="HorizontalAlignment" Value="Right"/>
+                                    </Trigger>
+                                    <Trigger Property="IsChecked" Value="False">
+                                        <Setter Property="Background" Value="#FFB0BEC5"/>
+                                        <Setter TargetName="Thumb" Property="HorizontalAlignment" Value="Left"/>
+                                    </Trigger>
+                                </ControlTemplate.Triggers>
+                            </ControlTemplate>
+                        </ToggleButton.Template>
+                    </ToggleButton>
+                </StackPanel>
+            </Grid>
+        </StackPanel>
+
+        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,20,0,0">
+            <Button x:Name="btnCancel" Content="Cancel" Width="90" Margin="0,0,10,0" Click="Cancel_Click"/>
+            <Button x:Name="btnSave" Content="Save" Width="90" Click="Save_Click" Background="#FF1976D2" Foreground="White"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Views/EditHotelDialog.xaml.cs
+++ b/Views/EditHotelDialog.xaml.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Windows;
+
+namespace Hotel_Booking_System.Views
+{
+    public partial class EditHotelDialog : Window
+    {
+        public EditHotelDialog()
+        {
+            InitializeComponent();
+        }
+
+        private void Save_Click(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is not DomainModels.Hotel hotel)
+            {
+                DialogResult = false;
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(hotel.HotelName) || string.IsNullOrWhiteSpace(hotel.City) || string.IsNullOrWhiteSpace(hotel.Address))
+            {
+                MessageBox.Show("Hotel name, city and address are required.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            if (hotel.MinPrice < 0 || hotel.MaxPrice < 0)
+            {
+                MessageBox.Show("Prices cannot be negative.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            if (hotel.MaxPrice < hotel.MinPrice)
+            {
+                MessageBox.Show("Maximum price cannot be lower than minimum price.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            if (hotel.Rating < 0 || hotel.Rating > 5)
+            {
+                MessageBox.Show("Rating must be between 0 and 5.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            DialogResult = true;
+            Close();
+        }
+
+        private void Cancel_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+            Close();
+        }
+    }
+}

--- a/Views/EditUserDialog.xaml
+++ b/Views/EditUserDialog.xaml
@@ -1,0 +1,76 @@
+<Window x:Class="Hotel_Booking_System.Views.EditUserDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Edit User"
+        Height="420"
+        Width="520"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        Background="#FFF8F9FA">
+    <Grid Margin="20">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock Text="Update user details"
+                   FontSize="20"
+                   FontWeight="Bold"
+                   Foreground="#FF1976D2"/>
+
+        <StackPanel Grid.Row="1" Margin="0,20,0,0">
+            <StackPanel Margin="0,0,0,12">
+                <TextBlock Text="Full name" FontWeight="SemiBold" Margin="0,0,0,4"/>
+                <TextBox Text="{Binding FullName, UpdateSourceTrigger=PropertyChanged}"/>
+            </StackPanel>
+
+            <Grid Margin="0,0,0,12">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+
+                <StackPanel Grid.Column="0" Margin="0,0,10,0">
+                    <TextBlock Text="Phone" FontWeight="SemiBold" Margin="0,0,0,4"/>
+                    <TextBox Text="{Binding Phone, UpdateSourceTrigger=PropertyChanged}"/>
+                </StackPanel>
+
+                <StackPanel Grid.Column="1">
+                    <TextBlock Text="Gender" FontWeight="SemiBold" Margin="0,0,0,4"/>
+                    <ComboBox SelectedValue="{Binding Gender, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                              SelectedValuePath="Content">
+                        <ComboBoxItem Content="Male"/>
+                        <ComboBoxItem Content="Female"/>
+                        <ComboBoxItem Content="Other"/>
+                    </ComboBox>
+                </StackPanel>
+            </Grid>
+
+            <StackPanel Margin="0,0,0,12">
+                <TextBlock Text="Email" FontWeight="SemiBold" Margin="0,0,0,4"/>
+                <TextBox Text="{Binding Email}" IsReadOnly="True" Background="#FFEFF2F7"/>
+            </StackPanel>
+
+            <StackPanel Margin="0,0,0,12">
+                <TextBlock Text="Date of birth" FontWeight="SemiBold" Margin="0,0,0,4"/>
+                <DatePicker SelectedDate="{Binding DateOfBirth, Mode=TwoWay}"/>
+            </StackPanel>
+
+            <StackPanel Margin="0,0,0,12">
+                <TextBlock Text="Role" FontWeight="SemiBold" Margin="0,0,0,4"/>
+                <ComboBox SelectedValue="{Binding Role, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                          SelectedValuePath="Content">
+                    <ComboBoxItem Content="Customer"/>
+                    <ComboBoxItem Content="HotelAdmin"/>
+                    <ComboBoxItem Content="SuperAdmin"/>
+                </ComboBox>
+            </StackPanel>
+        </StackPanel>
+
+        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,20,0,0">
+            <Button x:Name="btnCancel" Content="Cancel" Width="90" Margin="0,0,10,0" Click="Cancel_Click"/>
+            <Button x:Name="btnSave" Content="Save" Width="90" Click="Save_Click" Background="#FF1976D2" Foreground="White"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Views/EditUserDialog.xaml.cs
+++ b/Views/EditUserDialog.xaml.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Windows;
+
+namespace Hotel_Booking_System.Views
+{
+    public partial class EditUserDialog : Window
+    {
+        public EditUserDialog()
+        {
+            InitializeComponent();
+        }
+
+        private void Save_Click(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is not DomainModels.User user)
+            {
+                DialogResult = false;
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(user.FullName))
+            {
+                MessageBox.Show("Full name is required.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            if (user.DateOfBirth == default)
+            {
+                MessageBox.Show("Please select a valid date of birth.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(user.Role))
+            {
+                MessageBox.Show("Please select a user role.", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            DialogResult = true;
+            Close();
+        }
+
+        private void Cancel_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+            Close();
+        }
+    }
+}

--- a/Views/SuperAdminWindow.xaml
+++ b/Views/SuperAdminWindow.xaml
@@ -34,7 +34,8 @@
                 <TextBlock Text="{Binding CurrentUser.FullName}" Foreground="White" Style="{StaticResource HeaderTextStyle}" VerticalAlignment="Bottom"/>
 
                 <Button Content="Logout" Style="{StaticResource PrimaryButton}" Width="100"
-                       Background="#FFFF5722" Margin="5,0,0,0"/>
+                       Background="#FFFF5722" Margin="5,0,0,0"
+                       Command="{Binding LogoutCommand}"/>
             </StackPanel>
         </Grid>
 
@@ -314,18 +315,30 @@
                                             <DataGridTemplateColumn.CellTemplate>
                                                 <DataTemplate>
                                                     <StackPanel Orientation="Horizontal">
-                                                        <Button Content="👁️" ToolTip="View Details" Style="{StaticResource SecondaryButton}" 
-                                                   Width="25" Height="25" Margin="2" FontSize="10"/>
-                                                        <Button Content="✏️" ToolTip="Edit Hotel" Style="{StaticResource SecondaryButton}" 
-                                                   Background="#FF2196F3" Width="25" Height="25" Margin="2" FontSize="10"/>
-                                                        <Button Content="🏠" ToolTip="Manage Rooms" Style="{StaticResource SecondaryButton}" 
-                                                   Background="#FFFF9800" Width="25" Height="25" Margin="2" FontSize="10"/>
-                                                        <Button Content="📊" ToolTip="Analytics" Style="{StaticResource SecondaryButton}" 
-                                                   Background="#FF9C27B0" Width="25" Height="25" Margin="2" FontSize="10"/>
-                                                        <Button Content="⚠️" ToolTip="Suspend" Style="{StaticResource SecondaryButton}" 
-                                                   Background="#FFFF5722" Width="25" Height="25" Margin="2" FontSize="10"/>
-                                                        <Button Content="📧" ToolTip="Contact Admin" Style="{StaticResource SecondaryButton}" 
-                                                   Background="#FF607D8B" Width="25" Height="25" Margin="2" FontSize="10"/>
+                                                        <Button Content="👁️" ToolTip="View Details" Style="{StaticResource SecondaryButton}"
+                                                                Width="25" Height="25" Margin="2" FontSize="10"
+                                                                Command="{Binding DataContext.ViewHotelDetailsCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                                                CommandParameter="{Binding}"/>
+                                                        <Button Content="✏️" ToolTip="Edit Hotel" Style="{StaticResource SecondaryButton}"
+                                                                Background="#FF2196F3" Width="25" Height="25" Margin="2" FontSize="10"
+                                                                Command="{Binding DataContext.EditHotelAsyncCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                                                CommandParameter="{Binding}"/>
+                                                        <Button Content="🏠" ToolTip="Manage Rooms" Style="{StaticResource SecondaryButton}"
+                                                                Background="#FFFF9800" Width="25" Height="25" Margin="2" FontSize="10"
+                                                                Command="{Binding DataContext.ManageHotelRoomsAsyncCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                                                CommandParameter="{Binding}"/>
+                                                        <Button Content="📊" ToolTip="Analytics" Style="{StaticResource SecondaryButton}"
+                                                                Background="#FF9C27B0" Width="25" Height="25" Margin="2" FontSize="10"
+                                                                Command="{Binding DataContext.ShowHotelAnalyticsCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                                                CommandParameter="{Binding}"/>
+                                                        <Button Content="⚠️" ToolTip="Suspend" Style="{StaticResource SecondaryButton}"
+                                                                Background="#FFFF5722" Width="25" Height="25" Margin="2" FontSize="10"
+                                                                Command="{Binding DataContext.ToggleHotelVisibilityAsyncCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                                                CommandParameter="{Binding}"/>
+                                                        <Button Content="📧" ToolTip="Contact Admin" Style="{StaticResource SecondaryButton}"
+                                                                Background="#FF607D8B" Width="25" Height="25" Margin="2" FontSize="10"
+                                                                Command="{Binding DataContext.ContactHotelAdminAsyncCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                                                CommandParameter="{Binding}"/>
                                                     </StackPanel>
                                                 </DataTemplate>
                                             </DataGridTemplateColumn.CellTemplate>
@@ -416,26 +429,36 @@
 
                         <Border Style="{StaticResource CardStyle}">
                             <StackPanel Margin="25">
-                                <DataGrid Height="400" AutoGenerateColumns="False" CanUserAddRows="False">
+                                <DataGrid Height="400" AutoGenerateColumns="False" CanUserAddRows="False"
+                                          ItemsSource="{Binding Users}">
                                     <DataGrid.Columns>
-                                        <DataGridTextColumn Header="User ID" Width="80" Binding="{Binding UserId}"/>
-                                        <DataGridTextColumn Header="Name" Width="150" Binding="{Binding FullName}"/>
+                                        <DataGridTextColumn Header="User ID" Width="100" Binding="{Binding UserID}"/>
+                                        <DataGridTextColumn Header="Name" Width="160" Binding="{Binding FullName}"/>
                                         <DataGridTextColumn Header="Email" Width="200" Binding="{Binding Email}"/>
-                                        <DataGridTextColumn Header="Role" Width="100" Binding="{Binding Role}"/>
-                                        <DataGridTextColumn Header="Status" Width="80" Binding="{Binding Status}"/>
-                                        <DataGridTextColumn Header="Last Login" Width="100" Binding="{Binding LastLogin}"/>
+                                        <DataGridTextColumn Header="Phone" Width="120" Binding="{Binding Phone}"/>
+                                        <DataGridTextColumn Header="Gender" Width="100" Binding="{Binding Gender}"/>
+                                        <DataGridTextColumn Header="Role" Width="120" Binding="{Binding Role}"/>
+                                        <DataGridTextColumn Header="Date of Birth" Width="140" Binding="{Binding DateOfBirth, StringFormat='{}{0:dd/MM/yyyy}'}"/>
                                         <DataGridTemplateColumn Header="Actions" Width="200">
                                             <DataGridTemplateColumn.CellTemplate>
                                                 <DataTemplate>
                                                     <StackPanel Orientation="Horizontal">
-                                                        <Button Content="👁️" Style="{StaticResource SecondaryButton}" 
-                                                               Width="25" Height="25" Margin="2" FontSize="10"/>
-                                                        <Button Content="✏️" Style="{StaticResource SecondaryButton}" 
-                                                               Background="#FFFF9800" Width="25" Height="25" Margin="2" FontSize="10"/>
-                                                        <Button Content="🚫" Style="{StaticResource SecondaryButton}" 
-                                                               Background="#FFFF5722" Width="25" Height="25" Margin="2" FontSize="10"/>
-                                                        <Button Content="📧" Style="{StaticResource SecondaryButton}" 
-                                                               Background="#FF2196F3" Width="25" Height="25" Margin="2" FontSize="10"/>
+                                                        <Button Content="👁️" ToolTip="View Details" Style="{StaticResource SecondaryButton}"
+                                                               Width="25" Height="25" Margin="2" FontSize="10"
+                                                               Command="{Binding DataContext.ViewUserDetailsCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                                               CommandParameter="{Binding}"/>
+                                                        <Button Content="✏️" ToolTip="Edit User" Style="{StaticResource SecondaryButton}"
+                                                               Background="#FFFF9800" Width="25" Height="25" Margin="2" FontSize="10"
+                                                               Command="{Binding DataContext.EditUserAsyncCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                                               CommandParameter="{Binding}"/>
+                                                        <Button Content="🚫" ToolTip="Deactivate" Style="{StaticResource SecondaryButton}"
+                                                               Background="#FFFF5722" Width="25" Height="25" Margin="2" FontSize="10"
+                                                               Command="{Binding DataContext.DeactivateUserAsyncCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                                               CommandParameter="{Binding}"/>
+                                                        <Button Content="📧" ToolTip="Contact User" Style="{StaticResource SecondaryButton}"
+                                                               Background="#FF2196F3" Width="25" Height="25" Margin="2" FontSize="10"
+                                                               Command="{Binding DataContext.ContactUserAsyncCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                                               CommandParameter="{Binding}"/>
                                                     </StackPanel>
                                                 </DataTemplate>
                                             </DataGridTemplateColumn.CellTemplate>
@@ -681,25 +704,6 @@
 
                 </ScrollViewer>
 
-            </TabItem>
-
-
-            <TabItem x:Name="PaymentSummaryTab" Header="💰 Payment Summary">
-                <ScrollViewer Margin="30,20" VerticalScrollBarVisibility="Auto">
-                    <StackPanel>
-                        <TextBlock Text="Payment Summary" Style="{StaticResource HeaderTextStyle}"/>
-                        <DataGrid ItemsSource="{Binding Payments}" AutoGenerateColumns="False" CanUserAddRows="False" Margin="0,20,0,20">
-                            <DataGrid.Columns>
-                                <DataGridTextColumn Header="Payment ID" Binding="{Binding PaymentID}" Width="*"/>
-                                <DataGridTextColumn Header="Booking ID" Binding="{Binding BookingID}" Width="*"/>
-                                <DataGridTextColumn Header="Amount" Binding="{Binding TotalPayment}" Width="*"/>
-                                <DataGridTextColumn Header="Method" Binding="{Binding Method}" Width="*"/>
-                                <DataGridTextColumn Header="Date" Binding="{Binding PaymentDate}" Width="*"/>
-                            </DataGrid.Columns>
-                        </DataGrid>
-                        <TextBlock Text="{Binding TotalRevenue, StringFormat='Total Revenue: ${0:F0}'}" FontSize="16" FontWeight="Bold" Foreground="#27AE60" HorizontalAlignment="Right"/>
-                    </StackPanel>
-                </ScrollViewer>
             </TabItem>
 
 

--- a/Views/SuperAdminWindow.xaml.cs
+++ b/Views/SuperAdminWindow.xaml.cs
@@ -10,14 +10,12 @@ namespace Hotel_Booking_System.Views
 {
     public partial class SuperAdminWindow : Window
     {
-        private readonly IPaymentViewModel _paymentViewModel = App.Provider.GetRequiredService<IPaymentViewModel>();
         private readonly ISuperAdminViewModel _superAdminViewModel = App.Provider.GetRequiredService<ISuperAdminViewModel>();
 
         public SuperAdminWindow()
         {
             InitializeComponent();
             DataContext = _superAdminViewModel;
-            PaymentSummaryTab.DataContext = _paymentViewModel;
 
             txtCurrentPassword.PasswordChanged += (s, e) =>
             {
@@ -41,7 +39,6 @@ namespace Hotel_Booking_System.Views
 
             Loaded += async (s, e) =>
             {
-                await _paymentViewModel.LoadPaymentsAsync();
                 await _superAdminViewModel.LoadDataAsync();
             };
         }


### PR DESCRIPTION
## Summary
- register dedicated edit dialogs so the super admin dashboard can launch focused hotel and user editors
- expand the super admin view model with cached datasets plus commands for logout, hotel moderation, and user management actions
- wire the super admin UI to the new commands, surface real user data, and remove the unused payment summary tab

## Testing
- dotnet build *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de895d5f148333bf5efeb603898005